### PR TITLE
Client secret double encoding issue when updating an existing registered client

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/client/JdbcRegisteredClientRepository.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/client/JdbcRegisteredClientRepository.java
@@ -95,8 +95,7 @@ public class JdbcRegisteredClientRepository implements RegisteredClientRepositor
 
 	// @formatter:off
 	private static final String UPDATE_REGISTERED_CLIENT_SQL = "UPDATE " + TABLE_NAME
-			+ " SET client_secret = ?, client_secret_expires_at = ?,"
-			+ " client_name = ?, client_authentication_methods = ?, authorization_grant_types = ?,"
+			+ " SET client_name = ?, client_authentication_methods = ?, authorization_grant_types = ?,"
 			+ " redirect_uris = ?, scopes = ?, client_settings = ?, token_settings = ?"
 			+ " WHERE " + PK_FILTER;
 	// @formatter:on
@@ -134,6 +133,8 @@ public class JdbcRegisteredClientRepository implements RegisteredClientRepositor
 		SqlParameterValue id = parameters.remove(0);
 		parameters.remove(0); // remove client_id
 		parameters.remove(0); // remove client_id_issued_at
+		parameters.remove(0); // remove client_secret
+		parameters.remove(0); // remove client_secret_expires_at
 		parameters.add(id);
 		PreparedStatementSetter pss = new ArgumentPreparedStatementSetter(parameters.toArray());
 		this.jdbcOperations.update(UPDATE_REGISTERED_CLIENT_SQL, pss);


### PR DESCRIPTION
Avoid client secret double encoding when updating a registered client

Closes gh-389