### PR TITLE
authenticationDetailsSource of OAuth2TokenEndpointFilter should be customizable

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2TokenEndpointFilter.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2TokenEndpointFilter.java
@@ -104,7 +104,7 @@ public final class OAuth2TokenEndpointFilter extends OncePerRequestFilter {
 			new OAuth2AccessTokenResponseHttpMessageConverter();
 	private final HttpMessageConverter<OAuth2Error> errorHttpResponseConverter =
 			new OAuth2ErrorHttpMessageConverter();
-	private final AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource =
+	private AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource =
 			new WebAuthenticationDetailsSource();
 	private AuthenticationConverter authenticationConverter;
 	private AuthenticationSuccessHandler authenticationSuccessHandler = this::sendAccessTokenResponse;
@@ -168,6 +168,17 @@ public final class OAuth2TokenEndpointFilter extends OncePerRequestFilter {
 			SecurityContextHolder.clearContext();
 			this.authenticationFailureHandler.onAuthenticationFailure(request, response, ex);
 		}
+	}
+
+	/**
+	 * Sets the {@link AuthenticationDetailsSource} used for building an authentication details instance from {@link HttpServletRequest}.
+	 *
+	 * @param authenticationDetailsSource the {@link AuthenticationDetailsSource} used for building an authentication details instance from {@link HttpServletRequest}
+	 */
+	public void setAuthenticationDetailsSource(
+			AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource) {
+		Assert.notNull(authenticationDetailsSource, "authenticationDetailsSource cannot be null");
+		this.authenticationDetailsSource = authenticationDetailsSource;
 	}
 
 	/**


### PR DESCRIPTION
1. According to #431 , make the `authenticationDetailsSource` field of `OAuth2TokenEndpointFilter` customizable by making it non-final and adding a setter.
2. Add two tests to `OAuth2TokenEndpointFilterTests`, following the same way that `authenticationConverter`, `authenticationSuccessHandler` and `authenticationFailureHandler` are tested.
3. Modify `OAuth2TokenEndpointConfigurer` to let `authenticationDetailsSource` customizable through the configurer.
4. In `OAuth2ClientCredentialsGrantTests`, mock `authenticationDetailsSource` the same way that `authenticationConverter`, `authenticationSuccessHandler` and `authenticationFailureHandler` are mocked.
