### PR TITLE
Make OAuth2ClientAuthenticationToken @Transient

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientAuthenticationToken.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientAuthenticationToken.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.springframework.lang.Nullable;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.Transient;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.Version;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
@@ -37,6 +38,7 @@ import org.springframework.util.Assert;
  * @see RegisteredClient
  * @see OAuth2ClientAuthenticationProvider
  */
+@Transient
 public class OAuth2ClientAuthenticationToken extends AbstractAuthenticationToken {
 	private static final long serialVersionUID = Version.SERIAL_VERSION_UID;
 	private final String clientId;


### PR DESCRIPTION
`OAuth2ClientAuthenticationToken` represents an authentication for an OAuth2 client, specifically when making request to token endpoints (token, introspection, revocation). Those are protected resources and the requests should always be authenticated through OAuth2-specified mechanisms (client_secret, PKCE, mTLS). Client authentications need not be stored in sessions.