### PR TITLE
Update RegisteredClient.Builder to use getters

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/client/RegisteredClient.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/client/RegisteredClient.java
@@ -262,23 +262,23 @@ public class RegisteredClient implements Serializable {
 		}
 
 		protected Builder(RegisteredClient registeredClient) {
-			this.id = registeredClient.id;
-			this.clientId = registeredClient.clientId;
-			this.clientIdIssuedAt = registeredClient.clientIdIssuedAt;
-			this.clientSecret = registeredClient.clientSecret;
-			this.clientSecretExpiresAt = registeredClient.clientSecretExpiresAt;
-			this.clientName = registeredClient.clientName;
-			if (!CollectionUtils.isEmpty(registeredClient.clientAuthenticationMethods)) {
-				this.clientAuthenticationMethods.addAll(registeredClient.clientAuthenticationMethods);
+			this.id = registeredClient.getId();
+			this.clientId = registeredClient.getClientId();
+			this.clientIdIssuedAt = registeredClient.getClientIdIssuedAt();
+			this.clientSecret = registeredClient.getClientSecret();
+			this.clientSecretExpiresAt = registeredClient.getClientSecretExpiresAt();
+			this.clientName = registeredClient.getClientName();
+			if (!CollectionUtils.isEmpty(registeredClient.getClientAuthenticationMethods())) {
+				this.clientAuthenticationMethods.addAll(registeredClient.getClientAuthenticationMethods());
 			}
-			if (!CollectionUtils.isEmpty(registeredClient.authorizationGrantTypes)) {
-				this.authorizationGrantTypes.addAll(registeredClient.authorizationGrantTypes);
+			if (!CollectionUtils.isEmpty(registeredClient.getAuthorizationGrantTypes())) {
+				this.authorizationGrantTypes.addAll(registeredClient.getAuthorizationGrantTypes());
 			}
-			if (!CollectionUtils.isEmpty(registeredClient.redirectUris)) {
-				this.redirectUris.addAll(registeredClient.redirectUris);
+			if (!CollectionUtils.isEmpty(registeredClient.getRedirectUris())) {
+				this.redirectUris.addAll(registeredClient.getRedirectUris());
 			}
-			if (!CollectionUtils.isEmpty(registeredClient.scopes)) {
-				this.scopes.addAll(registeredClient.scopes);
+			if (!CollectionUtils.isEmpty(registeredClient.getScopes())) {
+				this.scopes.addAll(registeredClient.getScopes());
 			}
 			this.clientSettings = ClientSettings.withSettings(registeredClient.getClientSettings().getSettings()).build();
 			this.tokenSettings = TokenSettings.withSettings(registeredClient.getTokenSettings().getSettings()).build();


### PR DESCRIPTION
Since the class is not final, it is possible to extend it. Because the Builder was directly accessing the properties rather than using the getters/setters, it was not possible to use the .from(id) constructor in the extended class. This should enable extensions to use it.