### PR TITLE
Simplify OAuth2ClientAuthenticationProvider PKCE verifications

### DIFF
--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientAuthenticationProviderTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientAuthenticationProviderTests.java
@@ -208,9 +208,9 @@ public class OAuth2ClientAuthenticationProviderTests {
 	}
 
 	@Test
-	public void authenticateWhenPkceAndRequireProofKeyAndMissingCodeChallengeThenThrowOAuth2AuthenticationException() {
+	public void authenticateWhenPkceAndMissingCodeChallengeThenThrowOAuth2AuthenticationException() {
 		RegisteredClient registeredClient = TestRegisteredClients.registeredClient()
-				.clientSettings(ClientSettings.builder().requireProofKey(true).build())
+				.clientSettings(ClientSettings.builder().build())
 				.build();
 		when(this.registeredClientRepository.findByClientId(eq(registeredClient.getClientId())))
 				.thenReturn(registeredClient);


### PR DESCRIPTION
In `OAuth2ClientAuthenticationProvider`, if no authentication is available, codeVerifier is REQUIRED, and so is codeChallenge. The value of `requireProofKey` has no influence. Currently, if you set it to "false" in the `authenticateWhenPkceAndRequireProofKeyAndMissingCodeChallengeThenThrowOAuth2AuthenticationException` test, the result will be the same.

Simplified the code to match the current expectations.

`requireProofKey` is still a key part of 
`OAuth2AuthorizationCodeRequestAuthenticationProvider#authenticateAuthorizationRequest`, it requires the presence of a `codeChallenge`.