### PR TITLE
JdbcOAuth2AuthorizationService now used LobCreator in findBy method

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/JdbcOAuth2AuthorizationService.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/JdbcOAuth2AuthorizationService.java
@@ -253,9 +253,12 @@ public class JdbcOAuth2AuthorizationService implements OAuth2AuthorizationServic
 	}
 
 	private OAuth2Authorization findBy(String filter, List<SqlParameterValue> parameters) {
-		PreparedStatementSetter pss = new ArgumentPreparedStatementSetter(parameters.toArray());
-		List<OAuth2Authorization> result = this.jdbcOperations.query(LOAD_AUTHORIZATION_SQL + filter, pss, this.authorizationRowMapper);
-		return !result.isEmpty() ? result.get(0) : null;
+		try (LobCreator lobCreator = this.getLobHandler().getLobCreator()) {
+			PreparedStatementSetter pss = new LobCreatorArgumentPreparedStatementSetter(lobCreator,
+					parameters.toArray());
+			List<OAuth2Authorization> result = this.getJdbcOperations().query(LOAD_AUTHORIZATION_SQL + filter, pss, this.getAuthorizationRowMapper());
+			return !result.isEmpty() ? result.get(0) : null;
+		}
 	}
 
 	/**


### PR DESCRIPTION
When findBy called with parameter of type BLOB it raised exception of mapping (for Postgres as minimum). This error is processed in insertStatements and updateStatements by using LobCreator and LobCreatorArgumentPreparedStatement. Commit applies this approach to findBy method