### PR TITLE
Update gradle enterprise to 3.8 to address CVE-2021-45105.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-	id "com.gradle.enterprise" version "3.7.2"
+	id "com.gradle.enterprise" version "3.8"
 	id "io.spring.ge.conventions" version "0.0.7"
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-	id "com.gradle.enterprise" version "3.5.1"
+	id "com.gradle.enterprise" version "3.7.2"
 	id "io.spring.ge.conventions" version "0.0.7"
 }
 


### PR DESCRIPTION
https://security.gradle.com/advisory/2021-11