### PR TITLE
Add mappings to/from intermediate objects for NoSQL support

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/OAuth2AuthorizationConsentResource.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/OAuth2AuthorizationConsentResource.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization;
+
+import java.util.Set;
+
+/**
+ * Resource containing the data of an {@link OAuth2AuthorizationConsent} object.
+ *
+ * @author Steve Riesenberg
+ * @since 0.2.2
+ */
+public class OAuth2AuthorizationConsentResource {
+	private String registeredClientId;
+	private String principalName;
+	private Set<String> authorities;
+
+	public String getRegisteredClientId() {
+		return registeredClientId;
+	}
+
+	public void setRegisteredClientId(String registeredClientId) {
+		this.registeredClientId = registeredClientId;
+	}
+
+	public String getPrincipalName() {
+		return principalName;
+	}
+
+	public void setPrincipalName(String principalName) {
+		this.principalName = principalName;
+	}
+
+	public Set<String> getAuthorities() {
+		return authorities;
+	}
+
+	public void setAuthorities(Set<String> authorities) {
+		this.authorities = authorities;
+	}
+}

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/OAuth2AuthorizationResource.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/OAuth2AuthorizationResource.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Resource containing the data of an {@link OAuth2Authorization} object.
+ *
+ * @author Steve Riesenberg
+ * @since 0.2.2
+ */
+public class OAuth2AuthorizationResource {
+	private String id;
+	private String registeredClientId;
+	private String principalName;
+	private String authorizationGrantType;
+	private String state;
+	private Set<String> scopes;
+	private Map<String, Object> attributes;
+	private Map<String, OAuth2TokenResource> tokens;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getRegisteredClientId() {
+		return registeredClientId;
+	}
+
+	public void setRegisteredClientId(String registeredClientId) {
+		this.registeredClientId = registeredClientId;
+	}
+
+	public String getPrincipalName() {
+		return principalName;
+	}
+
+	public void setPrincipalName(String principalName) {
+		this.principalName = principalName;
+	}
+
+	public String getAuthorizationGrantType() {
+		return authorizationGrantType;
+	}
+
+	public void setAuthorizationGrantType(String authorizationGrantType) {
+		this.authorizationGrantType = authorizationGrantType;
+	}
+
+	public String getState() {
+		return state;
+	}
+
+	public void setState(String state) {
+		this.state = state;
+	}
+
+	public Set<String> getScopes() {
+		return scopes;
+	}
+
+	public void setScopes(Set<String> scopes) {
+		this.scopes = scopes;
+	}
+
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
+
+	public void setAttributes(Map<String, Object> attributes) {
+		this.attributes = attributes;
+	}
+
+	public Map<String, OAuth2TokenResource> getTokens() {
+		return tokens;
+	}
+
+	public void setTokens(Map<String, OAuth2TokenResource> tokens) {
+		this.tokens = tokens;
+	}
+
+	public static class OAuth2TokenResource {
+		private String tokenValue;
+		private Instant issuedAt;
+		private Instant expiresAt;
+		private Map<String, Object> metadata;
+
+		public String getTokenValue() {
+			return tokenValue;
+		}
+
+		public void setTokenValue(String tokenValue) {
+			this.tokenValue = tokenValue;
+		}
+
+		public Instant getIssuedAt() {
+			return issuedAt;
+		}
+
+		public void setIssuedAt(Instant issuedAt) {
+			this.issuedAt = issuedAt;
+		}
+
+		public Instant getExpiresAt() {
+			return expiresAt;
+		}
+
+		public void setExpiresAt(Instant expiresAt) {
+			this.expiresAt = expiresAt;
+		}
+
+		public Map<String, Object> getMetadata() {
+			return metadata;
+		}
+
+		public void setMetadata(Map<String, Object> metadata) {
+			this.metadata = metadata;
+		}
+	}
+}

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/OAuth2AuthorizationServerResourceMappers.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/OAuth2AuthorizationServerResourceMappers.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.*;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientResource;
+import org.springframework.security.oauth2.server.authorization.config.ClientSettings;
+import org.springframework.security.oauth2.server.authorization.config.TokenSettings;
+
+import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Support for mapping domain objects to/from resource objects with the ability to customize the mapping process.
+ * <p>
+ * The following objects are supported:
+ *
+ * <ul>
+ *   <li>{@link RegisteredClient} and {@link RegisteredClientResource}</li>
+ *   <li>{@link OAuth2Authorization} and {@link OAuth2AuthorizationResource}</li>
+ *   <li>{@link OAuth2AuthorizationConsent} and {@link OAuth2AuthorizationConsentResource}</li>
+ * </ul>
+ *
+ * @author Steve Riesenberg
+ * @since 0.2.2
+ */
+public final class OAuth2AuthorizationServerResourceMappers {
+
+	private static final Map<String, Class<? extends OAuth2Token>> TOKEN_TYPES;
+	static {
+		Map<String, Class<? extends OAuth2Token>> tokenTypes = new HashMap<>();
+		tokenTypes.put(AuthorizationGrantType.AUTHORIZATION_CODE.getValue(), OAuth2AuthorizationCode.class);
+		tokenTypes.put(OAuth2ParameterNames.ACCESS_TOKEN, OAuth2AccessToken.class);
+		tokenTypes.put(OAuth2ParameterNames.REFRESH_TOKEN, OAuth2RefreshToken.class);
+		tokenTypes.put(OidcParameterNames.ID_TOKEN, OidcIdToken.class);
+		TOKEN_TYPES = Collections.unmodifiableMap(tokenTypes);
+	}
+
+	private OAuth2AuthorizationServerResourceMappers() {
+	}
+
+	/**
+	 * Returns a {@link Function} for mapping a {@link RegisteredClient} to a {@link RegisteredClientResource}.
+	 *
+	 * @return A {@link Function} for mapping a {@link RegisteredClient} to a {@link RegisteredClientResource}
+	 */
+	public static Function<RegisteredClient, RegisteredClientResource> registeredClientResourceMapper() {
+		return registeredClientResourceMapper(RegisteredClientResource::new);
+	}
+
+	/**
+	 * Returns a {@link Function} for mapping a {@link RegisteredClient} to a {@link RegisteredClientResource}.
+	 *
+	 * @param registeredClientResourceSupplier A {@link Supplier} providing a custom object
+	 * @return A {@link Function} for mapping a {@link RegisteredClient} to a {@link RegisteredClientResource}
+	 */
+	public static Function<RegisteredClient, RegisteredClientResource> registeredClientResourceMapper(
+			Supplier<RegisteredClientResource> registeredClientResourceSupplier) {
+		return (registeredClient) -> {
+			Set<String> clientAuthenticationMethods = new HashSet<>();
+			registeredClient.getClientAuthenticationMethods().forEach(clientAuthenticationMethod ->
+					clientAuthenticationMethods.add(clientAuthenticationMethod.getValue()));
+
+			Set<String> authorizationGrantTypes = new HashSet<>();
+			registeredClient.getAuthorizationGrantTypes().forEach(authorizationGrantType ->
+					authorizationGrantTypes.add(authorizationGrantType.getValue()));
+
+			RegisteredClientResource registeredClientResource = registeredClientResourceSupplier.get();
+			registeredClientResource.setId(registeredClient.getId());
+			registeredClientResource.setClientId(registeredClient.getClientId());
+			registeredClientResource.setClientIdIssuedAt(registeredClient.getClientIdIssuedAt());
+			registeredClientResource.setClientSecret(registeredClient.getClientSecret());
+			registeredClientResource.setClientSecretExpiresAt(registeredClient.getClientSecretExpiresAt());
+			registeredClientResource.setClientName(registeredClient.getClientName());
+			registeredClientResource.setClientAuthenticationMethods(clientAuthenticationMethods);
+			registeredClientResource.setAuthorizationGrantTypes(authorizationGrantTypes);
+			registeredClientResource.setRedirectUris(registeredClient.getRedirectUris());
+			registeredClientResource.setScopes(registeredClient.getScopes());
+			registeredClientResource.setClientSettings(registeredClient.getClientSettings().getSettings());
+			registeredClientResource.setTokenSettings(registeredClient.getTokenSettings().getSettings());
+
+			return registeredClientResource;
+		};
+	}
+
+	/**
+	 * Returns a {@link Function} for mapping a {@link RegisteredClientResource} to a {@link RegisteredClient}.
+	 *
+	 * @return A {@link Function} for mapping a {@link RegisteredClientResource} to a {@link RegisteredClient}.
+	 */
+	public static Function<RegisteredClientResource, RegisteredClient> registeredClientMapper() {
+		return registeredClientMapper(defaultConsumer());
+	}
+
+	/**
+	 * Returns a {@link Function} for mapping a {@link RegisteredClientResource} to a {@link RegisteredClient}.
+	 *
+	 * @param registeredClientBuilderConsumer A {@link BiConsumer} used to access the builder for customizing the mapping
+	 * @return A {@link Function} for mapping a {@link RegisteredClientResource} to a {@link RegisteredClient}.
+	 */
+	public static Function<RegisteredClientResource, RegisteredClient> registeredClientMapper(
+			BiConsumer<RegisteredClientResource, RegisteredClient.Builder> registeredClientBuilderConsumer) {
+		return (registeredClientResource) -> {
+			RegisteredClient.Builder builder = RegisteredClient.withId(registeredClientResource.getId())
+					.clientId(registeredClientResource.getClientId())
+					.clientIdIssuedAt(registeredClientResource.getClientIdIssuedAt())
+					.clientSecret(registeredClientResource.getClientSecret())
+					.clientSecretExpiresAt(registeredClientResource.getClientSecretExpiresAt())
+					.clientName(registeredClientResource.getClientName())
+					.clientAuthenticationMethods(authenticationMethods ->
+							registeredClientResource.getClientAuthenticationMethods().forEach(authenticationMethod ->
+									authenticationMethods.add(resolveClientAuthenticationMethod(authenticationMethod))))
+					.authorizationGrantTypes((grantTypes) ->
+							registeredClientResource.getAuthorizationGrantTypes().forEach(grantType ->
+									grantTypes.add(resolveAuthorizationGrantType(grantType))))
+					.redirectUris((uris) -> uris.addAll(registeredClientResource.getRedirectUris()))
+					.scopes((scopes) -> scopes.addAll(registeredClientResource.getScopes()))
+					.clientSettings(ClientSettings.withSettings(registeredClientResource.getClientSettings()).build())
+					.tokenSettings(TokenSettings.withSettings(registeredClientResource.getTokenSettings()).build());
+			registeredClientBuilderConsumer.accept(registeredClientResource, builder);
+
+			return builder.build();
+		};
+	}
+
+	/**
+	 * Returns a {@link Function} for mapping a {@link OAuth2Authorization} to a {@link OAuth2AuthorizationResource}.
+	 *
+	 * @return A {@link Function} for mapping a {@link OAuth2Authorization} to a {@link OAuth2AuthorizationResource}.
+	 */
+	public static Function<OAuth2Authorization, OAuth2AuthorizationResource> authorizationResourceMapper() {
+		return authorizationResourceMapper(OAuth2AuthorizationResource::new);
+	}
+
+	/**
+	 * Returns a {@link Function} for mapping a {@link OAuth2Authorization} to a {@link OAuth2AuthorizationResource}.
+	 *
+	 * @param authorizationResourceSupplier A {@link Supplier} providing a custom object
+	 * @return A {@link Function} for mapping a {@link OAuth2Authorization} to a {@link OAuth2AuthorizationResource}.
+	 */
+	public static Function<OAuth2Authorization, OAuth2AuthorizationResource> authorizationResourceMapper(
+			Supplier<OAuth2AuthorizationResource> authorizationResourceSupplier) {
+		return (authorization) -> {
+			OAuth2AuthorizationResource authorizationResource = authorizationResourceSupplier.get();
+			authorizationResource.setId(authorization.getId());
+			authorizationResource.setRegisteredClientId(authorization.getRegisteredClientId());
+			authorizationResource.setPrincipalName(authorization.getPrincipalName());
+			authorizationResource.setAuthorizationGrantType(authorization.getAuthorizationGrantType().getValue());
+			authorizationResource.setState(authorization.getAttribute(OAuth2ParameterNames.STATE));
+			authorizationResource.setAttributes(authorization.getAttributes());
+
+			Map<String, OAuth2AuthorizationResource.OAuth2TokenResource> tokenResources = new HashMap<>();
+			TOKEN_TYPES.forEach((key, tokenType) -> {
+				OAuth2Authorization.Token<?> authorizationToken = authorization.getToken(tokenType);
+				if (authorizationToken != null) {
+					OAuth2Token token = authorizationToken.getToken();
+					if (token instanceof OAuth2AccessToken) {
+						// Set scopes as top-level field
+						OAuth2AccessToken accessToken = (OAuth2AccessToken) token;
+						authorizationResource.setScopes(accessToken.getScopes());
+					}
+
+					OAuth2AuthorizationResource.OAuth2TokenResource tokenResource =
+							new OAuth2AuthorizationResource.OAuth2TokenResource();
+					tokenResource.setTokenValue(token.getTokenValue());
+					tokenResource.setIssuedAt(token.getIssuedAt());
+					tokenResource.setExpiresAt(token.getExpiresAt());
+					tokenResource.setMetadata(authorizationToken.getMetadata());
+					tokenResources.put(key, tokenResource);
+				}
+			});
+			authorizationResource.setTokens(Collections.unmodifiableMap(tokenResources));
+
+			return authorizationResource;
+		};
+	}
+
+	/**
+	 * Returns a {@link Function} for mapping a {@link OAuth2AuthorizationResource} to a {@link OAuth2Authorization}.
+	 *
+	 * @return A {@link Function} for mapping a {@link OAuth2AuthorizationResource} to a {@link OAuth2Authorization}.
+	 */
+	public static Function<OAuth2AuthorizationResource, OAuth2Authorization> authorizationMapper() {
+		return authorizationMapper(defaultConsumer());
+	}
+
+	/**
+	 * Returns a {@link Function} for mapping a {@link OAuth2AuthorizationResource} to a {@link OAuth2Authorization}.
+	 *
+	 * @param authorizationBuilderConsumer A {@link BiConsumer} used to access the builder for customizing the mapping
+	 * @return A {@link Function} for mapping a {@link OAuth2AuthorizationResource} to a {@link OAuth2Authorization}.
+	 */
+	public static Function<OAuth2AuthorizationResource, OAuth2Authorization> authorizationMapper(
+			BiConsumer<OAuth2AuthorizationResource, OAuth2Authorization.Builder> authorizationBuilderConsumer) {
+		return (authorizationResource) -> {
+			OAuth2Authorization.Builder builder = new OAuth2Authorization.Builder(
+					authorizationResource.getRegisteredClientId())
+					.id(authorizationResource.getId())
+					.principalName(authorizationResource.getPrincipalName())
+					.authorizationGrantType(resolveAuthorizationGrantType(
+							authorizationResource.getAuthorizationGrantType()))
+					.attributes((attributes) -> attributes.putAll(authorizationResource.getAttributes()));
+			if (authorizationResource.getState() != null) {
+				builder.attribute(OAuth2ParameterNames.STATE, authorizationResource.getState());
+			}
+			TOKEN_TYPES.forEach((key, tokenType) -> {
+				OAuth2AuthorizationResource.OAuth2TokenResource tokenResource = authorizationResource.getTokens()
+						.get(key);
+				if (tokenResource != null) {
+					OAuth2Token token = createOAuth2Token(tokenType, tokenResource, authorizationResource);
+					builder.token(token, metadata -> metadata.putAll(tokenResource.getMetadata()));
+				}
+			});
+			authorizationBuilderConsumer.accept(authorizationResource, builder);
+
+			return builder.build();
+		};
+	}
+
+	/**
+	 * Returns a {@link Function} for mapping a {@link OAuth2AuthorizationConsent} to a
+	 * {@link OAuth2AuthorizationConsentResource}.
+	 *
+	 * @return A {@link Function} for mapping a {@link OAuth2AuthorizationConsent} to a
+	 * {@link OAuth2AuthorizationConsentResource}.
+	 */
+	public static Function<OAuth2AuthorizationConsent, OAuth2AuthorizationConsentResource> authorizationConsentResourceMapper() {
+		return authorizationConsentResourceMapper(OAuth2AuthorizationConsentResource::new);
+	}
+
+	/**
+	 * Returns a {@link Function} for mapping a {@link OAuth2AuthorizationConsent} to a
+	 * {@link OAuth2AuthorizationConsentResource}.
+	 *
+	 * @param authorizationConsentResourceSupplier A {@link Supplier} providing a custom object
+	 * @return A {@link Function} for mapping a {@link OAuth2AuthorizationConsent} to a
+	 * {@link OAuth2AuthorizationConsentResource}.
+	 */
+	public static Function<OAuth2AuthorizationConsent, OAuth2AuthorizationConsentResource> authorizationConsentResourceMapper(
+			Supplier<OAuth2AuthorizationConsentResource> authorizationConsentResourceSupplier) {
+		return (authorizationConsent) -> {
+			OAuth2AuthorizationConsentResource authorizationConsentResource =
+					authorizationConsentResourceSupplier.get();
+			authorizationConsentResource.setRegisteredClientId(authorizationConsent.getRegisteredClientId());
+			authorizationConsentResource.setPrincipalName(authorizationConsent.getPrincipalName());
+
+			Set<String> authorities = new HashSet<>();
+			authorizationConsent.getAuthorities().forEach(authority -> authorities.add(authority.getAuthority()));
+			authorizationConsentResource.setAuthorities(authorities);
+
+			return authorizationConsentResource;
+		};
+	}
+
+	/**
+	 * Returns a {@link Function} for mapping a {@link OAuth2AuthorizationConsentResource} to a
+	 * {@link OAuth2AuthorizationConsent}.
+	 *
+	 * @return A {@link Function} for mapping a {@link OAuth2AuthorizationConsentResource} to a
+	 * {@link OAuth2AuthorizationConsent}.
+	 */
+	public static Function<OAuth2AuthorizationConsentResource, OAuth2AuthorizationConsent> authorizationConsentMapper() {
+		return authorizationConsentMapper(defaultConsumer());
+	}
+
+	/**
+	 * Returns a {@link Function} for mapping a {@link OAuth2AuthorizationConsentResource} to a
+	 * {@link OAuth2AuthorizationConsent}.
+	 *
+	 * @param authorizationConsentBuilderConsumer A {@link BiConsumer} used to access the builder for customizing the mapping
+	 * @return A {@link Function} for mapping a {@link OAuth2AuthorizationConsentResource} to a
+	 * {@link OAuth2AuthorizationConsent}.
+	 */
+	public static Function<OAuth2AuthorizationConsentResource, OAuth2AuthorizationConsent> authorizationConsentMapper(
+			BiConsumer<OAuth2AuthorizationConsentResource, OAuth2AuthorizationConsent.Builder> authorizationConsentBuilderConsumer) {
+		return (authorizationConsentResource) -> {
+			OAuth2AuthorizationConsent.Builder builder = OAuth2AuthorizationConsent.withId(
+					authorizationConsentResource.getRegisteredClientId(),
+					authorizationConsentResource.getPrincipalName());
+			authorizationConsentResource.getAuthorities().forEach(authority ->
+					builder.authority(new SimpleGrantedAuthority(authority)));
+			authorizationConsentBuilderConsumer.accept(authorizationConsentResource, builder);
+
+			return builder.build();
+		};
+	}
+
+	// @formatter:off
+	private static OAuth2Token createOAuth2Token(
+			Class<? extends OAuth2Token> tokenType,
+			OAuth2AuthorizationResource.OAuth2TokenResource tokenResource,
+			OAuth2AuthorizationResource authorizationResource) {
+		if (tokenType == OAuth2AuthorizationCode.class) {
+			return new OAuth2AuthorizationCode(
+					tokenResource.getTokenValue(),
+					tokenResource.getIssuedAt(),
+					tokenResource.getExpiresAt());
+		} else if (tokenType == OAuth2AccessToken.class) {
+			return new OAuth2AccessToken(
+					OAuth2AccessToken.TokenType.BEARER,
+					tokenResource.getTokenValue(),
+					tokenResource.getIssuedAt(),
+					tokenResource.getExpiresAt(),
+					authorizationResource.getScopes());
+		} else if (tokenType == OAuth2RefreshToken.class) {
+			return new OAuth2RefreshToken(
+					tokenResource.getTokenValue(),
+					tokenResource.getIssuedAt(),
+					tokenResource.getExpiresAt());
+		} else if (tokenType == OidcIdToken.class) {
+			@SuppressWarnings("unchecked")
+			Map<String, Object> claims = (Map<String, Object>) tokenResource.getMetadata()
+					.get(OAuth2Authorization.Token.CLAIMS_METADATA_NAME);
+			return new OidcIdToken(
+					tokenResource.getTokenValue(),
+					tokenResource.getIssuedAt(),
+					tokenResource.getExpiresAt(),
+					claims);
+		}
+		return null;
+	}
+	// @formatter:on
+
+	private static ClientAuthenticationMethod resolveClientAuthenticationMethod(String clientAuthenticationMethod) {
+		if (ClientAuthenticationMethod.CLIENT_SECRET_BASIC.getValue().equals(clientAuthenticationMethod)) {
+			return ClientAuthenticationMethod.CLIENT_SECRET_BASIC;
+		} else if (ClientAuthenticationMethod.CLIENT_SECRET_POST.getValue().equals(clientAuthenticationMethod)) {
+			return ClientAuthenticationMethod.CLIENT_SECRET_POST;
+		} else if (ClientAuthenticationMethod.CLIENT_SECRET_JWT.getValue().equals(clientAuthenticationMethod)) {
+			return ClientAuthenticationMethod.CLIENT_SECRET_JWT;
+		} else if (ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue().equals(clientAuthenticationMethod)) {
+			return ClientAuthenticationMethod.PRIVATE_KEY_JWT;
+		} else if (ClientAuthenticationMethod.NONE.getValue().equals(clientAuthenticationMethod)) {
+			return ClientAuthenticationMethod.NONE;
+		}
+		return new ClientAuthenticationMethod(clientAuthenticationMethod);      // Custom client authentication method
+	}
+
+	private static AuthorizationGrantType resolveAuthorizationGrantType(String authorizationGrantType) {
+		if (AuthorizationGrantType.AUTHORIZATION_CODE.getValue().equals(authorizationGrantType)) {
+			return AuthorizationGrantType.AUTHORIZATION_CODE;
+		} else if (AuthorizationGrantType.CLIENT_CREDENTIALS.getValue().equals(authorizationGrantType)) {
+			return AuthorizationGrantType.CLIENT_CREDENTIALS;
+		} else if (AuthorizationGrantType.REFRESH_TOKEN.getValue().equals(authorizationGrantType)) {
+			return AuthorizationGrantType.REFRESH_TOKEN;
+		} else if (AuthorizationGrantType.JWT_BEARER.getValue().equals(authorizationGrantType)) {
+			return AuthorizationGrantType.JWT_BEARER;
+		}
+		return new AuthorizationGrantType(authorizationGrantType);              // Custom authorization grant type
+	}
+
+	private static <T, B> BiConsumer<T, B> defaultConsumer() {
+		return (resource, builder) -> {
+		};
+	}
+}

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/client/RegisteredClientResource.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/client/RegisteredClientResource.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization.client;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Resource containing the data of an {@link RegisteredClient} object.
+ *
+ * @author Steve Riesenberg
+ * @since 0.2.2
+ */
+public class RegisteredClientResource {
+	private String id;
+	private String clientId;
+	private Instant clientIdIssuedAt;
+	private String clientSecret;
+	private Instant clientSecretExpiresAt;
+	private String clientName;
+	private Set<String> clientAuthenticationMethods;
+	private Set<String> authorizationGrantTypes;
+	private Set<String> redirectUris;
+	private Set<String> scopes;
+	private Map<String, Object> clientSettings;
+	private Map<String, Object> tokenSettings;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getClientId() {
+		return clientId;
+	}
+
+	public void setClientId(String clientId) {
+		this.clientId = clientId;
+	}
+
+	public Instant getClientIdIssuedAt() {
+		return clientIdIssuedAt;
+	}
+
+	public void setClientIdIssuedAt(Instant clientIdIssuedAt) {
+		this.clientIdIssuedAt = clientIdIssuedAt;
+	}
+
+	public String getClientSecret() {
+		return clientSecret;
+	}
+
+	public void setClientSecret(String clientSecret) {
+		this.clientSecret = clientSecret;
+	}
+
+	public Instant getClientSecretExpiresAt() {
+		return clientSecretExpiresAt;
+	}
+
+	public void setClientSecretExpiresAt(Instant clientSecretExpiresAt) {
+		this.clientSecretExpiresAt = clientSecretExpiresAt;
+	}
+
+	public String getClientName() {
+		return clientName;
+	}
+
+	public void setClientName(String clientName) {
+		this.clientName = clientName;
+	}
+
+	public Set<String> getClientAuthenticationMethods() {
+		return clientAuthenticationMethods;
+	}
+
+	public void setClientAuthenticationMethods(Set<String> clientAuthenticationMethods) {
+		this.clientAuthenticationMethods = clientAuthenticationMethods;
+	}
+
+	public Set<String> getAuthorizationGrantTypes() {
+		return authorizationGrantTypes;
+	}
+
+	public void setAuthorizationGrantTypes(Set<String> authorizationGrantTypes) {
+		this.authorizationGrantTypes = authorizationGrantTypes;
+	}
+
+	public Set<String> getRedirectUris() {
+		return redirectUris;
+	}
+
+	public void setRedirectUris(Set<String> redirectUris) {
+		this.redirectUris = redirectUris;
+	}
+
+	public Set<String> getScopes() {
+		return scopes;
+	}
+
+	public void setScopes(Set<String> scopes) {
+		this.scopes = scopes;
+	}
+
+	public Map<String, Object> getClientSettings() {
+		return clientSettings;
+	}
+
+	public void setClientSettings(Map<String, Object> clientSettings) {
+		this.clientSettings = clientSettings;
+	}
+
+	public Map<String, Object> getTokenSettings() {
+		return tokenSettings;
+	}
+
+	public void setTokenSettings(Map<String, Object> tokenSettings) {
+		this.tokenSettings = tokenSettings;
+	}
+}

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/jackson2/OAuth2AuthorizationServerJackson2Module.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/jackson2/OAuth2AuthorizationServerJackson2Module.java
@@ -15,18 +15,20 @@
  */
 package org.springframework.security.oauth2.server.authorization.jackson2;
 
-import java.time.Duration;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-
 import org.springframework.security.jackson2.SecurityJackson2Modules;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentResource;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationResource;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientResource;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 
 /**
  * Jackson {@code Module} for {@code spring-authorization-server}, that registers the
@@ -78,6 +80,10 @@ public class OAuth2AuthorizationServerJackson2Module extends SimpleModule {
 		context.setMixInAnnotations(Duration.class, DurationMixin.class);
 		context.setMixInAnnotations(SignatureAlgorithm.class, JwsAlgorithmMixin.class);
 		context.setMixInAnnotations(MacAlgorithm.class, JwsAlgorithmMixin.class);
+		context.setMixInAnnotations(RegisteredClientResource.class, ResourceMixin.class);
+		context.setMixInAnnotations(OAuth2AuthorizationResource.class, ResourceMixin.class);
+		context.setMixInAnnotations(OAuth2AuthorizationResource.OAuth2TokenResource.class, ResourceMixin.class);
+		context.setMixInAnnotations(OAuth2AuthorizationConsentResource.class, ResourceMixin.class);
 	}
 
 }

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/jackson2/ResourceMixin.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/jackson2/ResourceMixin.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization.jackson2;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ResourceMixin {
+}

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/OAuth2AuthorizationServerResourceMappersTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/OAuth2AuthorizationServerResourceMappersTests.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.jackson2.SecurityJackson2Modules;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientResource;
+import org.springframework.security.oauth2.server.authorization.client.TestRegisteredClients;
+import org.springframework.security.oauth2.server.authorization.jackson2.OAuth2AuthorizationServerJackson2Module;
+import org.springframework.security.oauth2.server.authorization.jackson2.TestingAuthenticationTokenMixin;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link OAuth2AuthorizationServerResourceMappers}.
+ *
+ * @author Steve Riesenberg
+ */
+public class OAuth2AuthorizationServerResourceMappersTests {
+
+	private final Function<RegisteredClient, RegisteredClientResource> registeredClientResourceMapper =
+			OAuth2AuthorizationServerResourceMappers.registeredClientResourceMapper();
+	private final Function<RegisteredClientResource, RegisteredClient> registeredClientMapper =
+			OAuth2AuthorizationServerResourceMappers.registeredClientMapper();
+	private final Function<OAuth2Authorization, OAuth2AuthorizationResource> authorizationResourceMapper =
+			OAuth2AuthorizationServerResourceMappers.authorizationResourceMapper();
+	private final Function<OAuth2AuthorizationResource, OAuth2Authorization> authorizationMapper =
+			OAuth2AuthorizationServerResourceMappers.authorizationMapper();
+	private final Function<OAuth2AuthorizationConsent, OAuth2AuthorizationConsentResource> authorizationConsentResourceMapper =
+			OAuth2AuthorizationServerResourceMappers.authorizationConsentResourceMapper();
+	private final Function<OAuth2AuthorizationConsentResource, OAuth2AuthorizationConsent> authorizationConsentMapper =
+			OAuth2AuthorizationServerResourceMappers.authorizationConsentMapper();
+
+	private ObjectMapper objectMapper;
+
+	@Before
+	public void setup() {
+		ClassLoader classLoader = OAuth2AuthorizationServerResourceMappers.class.getClassLoader();
+		List<Module> securityModules = SecurityJackson2Modules.getModules(classLoader);
+		this.objectMapper = new ObjectMapper();
+		this.objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+		this.objectMapper.registerModules(securityModules);
+		this.objectMapper.registerModule(new OAuth2AuthorizationServerJackson2Module());
+		this.objectMapper.addMixIn(TestingAuthenticationToken.class, TestingAuthenticationTokenMixin.class);
+	}
+
+	@Test
+	public void registeredClientMapperWhenMapperAppliedThenEquals() {
+		RegisteredClient registeredClient = TestRegisteredClients.registeredClient().build();
+		RegisteredClientResource registeredClientResource =
+				this.registeredClientResourceMapper.apply(registeredClient);
+		RegisteredClient registeredClient2 = this.registeredClientMapper.apply(registeredClientResource);
+		assertThat(registeredClient).isEqualTo(registeredClient2);
+	}
+
+	@Test
+	public void registeredClientMapperWhenConvertedToJsonThenEquals() throws Exception {
+		RegisteredClient registeredClient = TestRegisteredClients.registeredClient().build();
+		RegisteredClientResource registeredClientResource = this.registeredClientResourceMapper.apply(registeredClient);
+		String registeredClientJson = this.objectMapper.writeValueAsString(registeredClientResource);
+		RegisteredClientResource registeredClientResource2 =
+				this.objectMapper.readValue(registeredClientJson, RegisteredClientResource.class);
+		RegisteredClient registeredClient2 = this.registeredClientMapper.apply(registeredClientResource2);
+		assertThat(registeredClient).isEqualTo(registeredClient2);
+	}
+
+	@Test
+	public void authorizationMapperWhenMapperAppliedThenEquals() {
+		OAuth2Authorization authorization = TestOAuth2Authorizations.authorization().build();
+		OAuth2AuthorizationResource authorizationResource = this.authorizationResourceMapper.apply(authorization);
+		OAuth2Authorization authorization2 = this.authorizationMapper.apply(authorizationResource);
+		assertThat(authorization).isEqualTo(authorization2);
+	}
+
+	@Test
+	public void authorizationMapperWhenConvertedToJsonThenEquals() throws Exception {
+		OAuth2Authorization authorization = TestOAuth2Authorizations.authorization()
+				// Remove OAuth2AuthorizationRequest as it does not currently implement equals()
+				// which fails the below assertion
+				.attributes(attributes -> attributes.remove(OAuth2AuthorizationRequest.class.getName()))
+				.build();
+		OAuth2AuthorizationResource authorizationResource = this.authorizationResourceMapper.apply(authorization);
+		String authorizationJson = this.objectMapper.writeValueAsString(authorizationResource);
+		OAuth2AuthorizationResource authorizationResource2 =
+				this.objectMapper.readValue(authorizationJson, OAuth2AuthorizationResource.class);
+		OAuth2Authorization authorization2 = this.authorizationMapper.apply(authorizationResource2);
+		assertThat(authorization).isEqualTo(authorization2);
+	}
+
+	@Test
+	public void authorizationConsentMapperWhenMapperAppliedThenEquals() {
+		OAuth2AuthorizationConsent authorizationConsent = OAuth2AuthorizationConsent.withId("client-1", "user1")
+				.authority(new SimpleGrantedAuthority("some.authority"))
+				.build();
+		OAuth2AuthorizationConsentResource authorizationConsentResource =
+				this.authorizationConsentResourceMapper.apply(authorizationConsent);
+		OAuth2AuthorizationConsent authorizationConsent2 =
+				this.authorizationConsentMapper.apply(authorizationConsentResource);
+		assertThat(authorizationConsent).isEqualTo(authorizationConsent2);
+	}
+
+	@Test
+	public void authorizationConsentMapperWhenConvertedToJsonThenEquals() throws Exception {
+		OAuth2AuthorizationConsent authorizationConsent = OAuth2AuthorizationConsent.withId("client-1", "user1")
+				.authority(new SimpleGrantedAuthority("some.authority"))
+				.build();
+		OAuth2AuthorizationConsentResource authorizationConsentResource =
+				this.authorizationConsentResourceMapper.apply(authorizationConsent);
+		String authorizationConsentJson = this.objectMapper.writeValueAsString(authorizationConsentResource);
+		OAuth2AuthorizationConsentResource authorizationConsentResource2 =
+				this.objectMapper.readValue(authorizationConsentJson, OAuth2AuthorizationConsentResource.class);
+		OAuth2AuthorizationConsent authorizationConsent2 =
+				this.authorizationConsentMapper.apply(authorizationConsentResource2);
+		assertThat(authorizationConsent).isEqualTo(authorizationConsent2);
+	}
+}


### PR DESCRIPTION
This is a draft solution for supporting NoSQL databases. It uses intermediary objects (currently called "Resources", but open to better names) to simplify a transformation to/from JSON. The intermediary objects support full serialization to JSON with the use of the `OAuth2AuthorizationServerJackson2Module`. Supports the following:

* Handles iterating/mapping supported token types, removing the need for applications to do this
* Converts enumerated types to/from strings with support for "custom" types
* Converts authorities to/from strings
* Supports custom settings values

Issue gh-558