### PR TITLE
jdk version is incorrect in Prerequisities

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -52,7 +52,7 @@ In the instructions below, https://vimeo.com/34436402[`./gradlew`] is invoked fr
 a cross-platform, self-contained bootstrap mechanism for the build.
 
 === Prerequisites
-https://help.github.com/set-up-git-redirect[Git] and the https://www.oracle.com/technetwork/java/javase/downloads[JDK8 build].
+https://help.github.com/set-up-git-redirect[Git] and the https://www.oracle.com/technetwork/java/javase/downloads[JDK11 build].
 
 Be sure that your `JAVA_HOME` environment variable points to the `jdk11` folder extracted from the JDK download.
 

--- a/README.adoc
+++ b/README.adoc
@@ -54,7 +54,7 @@ a cross-platform, self-contained bootstrap mechanism for the build.
 === Prerequisites
 https://help.github.com/set-up-git-redirect[Git] and the https://www.oracle.com/technetwork/java/javase/downloads[JDK8 build].
 
-Be sure that your `JAVA_HOME` environment variable points to the `jdk1.8.0` folder extracted from the JDK download.
+Be sure that your `JAVA_HOME` environment variable points to the `jdk11` folder extracted from the JDK download.
 
 === Check out sources
 [indent=0]


### PR DESCRIPTION
when `JAVA_HOME` environment variable points to `jdk1.8.0` folder & ./gradlew build, I met the below error.
```
> Task :buildSrc:compileJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':buildSrc:compileJava'.
> invalid source release: 11

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s

```

After `JAVA_HOME` environment variable points to `jdk11` folder, build success