### PR TITLE
Fix deserialize incompatibility with Okta ver claim

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/jackson2/LongMixin.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/jackson2/LongMixin.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization.jackson2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * This mixin class is used to serialize/deserialize {@link Long} for solving a compatibility issue with the Okta "ver"
+ * claim.
+ *
+ * @author Stephen Kinser
+ * @since 0.2.4
+ */
+abstract class LongMixin {
+	@SuppressWarnings("unused")
+	@JsonProperty("long")
+	Long value;
+}

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/jackson2/OAuth2AuthorizationServerJackson2Module.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/jackson2/OAuth2AuthorizationServerJackson2Module.java
@@ -82,6 +82,7 @@ public class OAuth2AuthorizationServerJackson2Module extends SimpleModule {
 		context.setMixInAnnotations(SignatureAlgorithm.class, JwsAlgorithmMixin.class);
 		context.setMixInAnnotations(MacAlgorithm.class, JwsAlgorithmMixin.class);
 		context.setMixInAnnotations(OAuth2TokenFormat.class, OAuth2TokenFormatMixin.class);
+		context.setMixInAnnotations(Long.class, LongMixin.class);
 	}
 
 }

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/jackson2/OAuth2AuthorizationServerJackson2ModuleTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/jackson2/OAuth2AuthorizationServerJackson2ModuleTests.java
@@ -71,4 +71,11 @@ public class OAuth2AuthorizationServerJackson2ModuleTests {
 		String json = this.objectMapper.writeValueAsString(set);
 		assertThat(this.objectMapper.readValue(json, STRING_SET)).isEqualTo(set);
 	}
+
+	@Test
+	public void readValueWhenUnmodifiableMapWithLongThenSuccess() throws Exception {
+		Map<String, Object> map = Collections.unmodifiableMap(new HashMap<>(Collections.singletonMap("ver", 1L)));
+		String json = this.objectMapper.writeValueAsString(map);
+		assertThat(this.objectMapper.readValue(json, STRING_OBJECT_MAP)).isEqualTo(map);
+	}
 }


### PR DESCRIPTION
Okta includes a "ver" claim in the ID tokens it issues that gets serialized to json, as follows:
{
  "@class": "java.util.Collections$UnmodifiableMap",
  "ver": [
    "java.lang.Long",
    1
  ]
}

This claim is added by Okta automatically (see https://developer.okta.com/docs/reference/api/oidc/#id-token).

Spring Authorization Server encounters an error when attempting to deserialize this claim from Okta, as follows:
The class with java.lang.Long and name of java.lang.Long is not in the allowlist. If you believe this class is safe to deserialize, please provide an explicit mapping using Jackson annotations or by providing a Mixin. If the serialization is only done by a trusted source, you can also enable default typing. See https://github.com/spring-projects/spring-security/issues/4370 for details
java.lang.IllegalArgumentException: The class with java.lang.Long and name of java.lang.Long is not in the allowlist. If you believe this class is safe to deserialize, please provide an explicit mapping using Jackson annotations or by providing a Mixin. If the serialization is only done by a trusted source, you can also enable default typing. See https://github.com/spring-projects/spring-security/issues/4370 for details
	at org.springframework.security.jackson2.SecurityJackson2Modules$AllowlistTypeIdResolver.typeFromId(SecurityJackson2Modules.java:253)

The issue at https://github.com/spring-projects/spring-authorization-server/issues/567 has a similar symptom, though the situation being addressed in this pull request is different in that it would be encountered by any project wanting to do OpenID Connect with Okta. I thus recommend a general fix rather than a project-specific fix as recommended at https://github.com/spring-projects/spring-authorization-server/issues/397.

This commit defines a mixin that doesn't alter the json formatting but does instruct SecurityJackson2Modules.AllowlistTypeIdResolver to permit the deseralization of that Okta claim.