### PR TITLE
URL-encoded parameters in redirect URI are encoded twice

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationEndpointFilter.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationEndpointFilter.java
@@ -66,6 +66,8 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+import org.springframework.web.util.UriBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
@@ -296,8 +298,10 @@ public final class OAuth2AuthorizationEndpointFilter extends OncePerRequestFilte
 
 		OAuth2AuthorizationCodeRequestAuthenticationToken authorizationCodeRequestAuthentication =
 				(OAuth2AuthorizationCodeRequestAuthenticationToken) authentication;
-		UriComponentsBuilder uriBuilder = UriComponentsBuilder
-				.fromUriString(authorizationCodeRequestAuthentication.getRedirectUri())
+		DefaultUriBuilderFactory uriBuilderFactory = new DefaultUriBuilderFactory();
+		uriBuilderFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
+		UriBuilder uriBuilder = uriBuilderFactory
+				.uriString(authorizationCodeRequestAuthentication.getRedirectUri())
 				.queryParam(OAuth2ParameterNames.CODE, authorizationCodeRequestAuthentication.getAuthorizationCode().getTokenValue());
 		String redirectUri;
 		if (StringUtils.hasText(authorizationCodeRequestAuthentication.getState())) {
@@ -306,7 +310,7 @@ public final class OAuth2AuthorizationEndpointFilter extends OncePerRequestFilte
 			queryParams.put(OAuth2ParameterNames.STATE, authorizationCodeRequestAuthentication.getState());
 			redirectUri = uriBuilder.build(queryParams).toString();
 		} else {
-			redirectUri = uriBuilder.toUriString();
+			redirectUri = uriBuilder.build().toString();
 		}
 		this.redirectStrategy.sendRedirect(request, response, redirectUri);
 	}

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/client/TestRegisteredClients.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/client/TestRegisteredClients.java
@@ -39,6 +39,18 @@ public class TestRegisteredClients {
 				.scope("scope1");
 	}
 
+	public static RegisteredClient.Builder registeredClientEncodedUri() {
+		return RegisteredClient.withId("registration-1")
+				.clientId("client-1")
+				.clientIdIssuedAt(Instant.now().truncatedTo(ChronoUnit.SECONDS))
+				.clientSecret("secret-1")
+				.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+				.authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+				.clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+				.redirectUri("https://example.com?param=is%2Fencoded")
+				.scope("scope1");
+	}
+
 	public static RegisteredClient.Builder registeredClient2() {
 		return RegisteredClient.withId("registration-2")
 				.clientId("client-2")

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationEndpointFilterTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationEndpointFilterTests.java
@@ -83,7 +83,7 @@ import static org.mockito.Mockito.when;
 public class OAuth2AuthorizationEndpointFilterTests {
 	private static final String DEFAULT_AUTHORIZATION_ENDPOINT_URI = "/oauth2/authorize";
 	private static final String AUTHORIZATION_URI = "https://provider.com/oauth2/authorize";
-	private static final String STATE = "state";
+	private static final String STATE = "previously encoded/state";
 	private static final String REMOTE_ADDRESS = "remote-address";
 	private AuthenticationManager authenticationManager;
 	private OAuth2AuthorizationEndpointFilter filter;
@@ -299,7 +299,7 @@ public class OAuth2AuthorizationEndpointFilterTests {
 		verifyNoInteractions(filterChain);
 
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.FOUND.value());
-		assertThat(response.getRedirectedUrl()).isEqualTo("https://example.com?error=errorCode&error_description=errorDescription&error_uri=errorUri&state=state");
+		assertThat(response.getRedirectedUrl()).isEqualTo("https://example.com?error=errorCode&error_description=errorDescription&error_uri=errorUri&state=previously%20encoded%2Fstate");
 		assertThat(SecurityContextHolder.getContext().getAuthentication()).isSameAs(this.principal);
 	}
 
@@ -459,7 +459,7 @@ public class OAuth2AuthorizationEndpointFilterTests {
 		verifyNoInteractions(filterChain);
 
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.FOUND.value());
-		assertThat(response.getRedirectedUrl()).isEqualTo("http://localhost/oauth2/custom-consent?scope=scope1%20scope2&client_id=client-1&state=state");
+		assertThat(response.getRedirectedUrl()).isEqualTo("http://localhost/oauth2/custom-consent?scope=scope1%20scope2&client_id=client-1&state=previously%20encoded/state");
 	}
 
 	@Test
@@ -535,7 +535,7 @@ public class OAuth2AuthorizationEndpointFilterTests {
 
 	@Test
 	public void doFilterWhenAuthorizationRequestAuthenticatedThenAuthorizationResponse() throws Exception {
-		RegisteredClient registeredClient = TestRegisteredClients.registeredClient().build();
+		RegisteredClient registeredClient = TestRegisteredClients.registeredClientEncodedUri().build();
 		OAuth2AuthorizationCodeRequestAuthenticationToken authorizationCodeRequestAuthenticationResult =
 				new OAuth2AuthorizationCodeRequestAuthenticationToken(
 						AUTHORIZATION_URI, registeredClient.getClientId(), principal, this.authorizationCode,
@@ -560,7 +560,7 @@ public class OAuth2AuthorizationEndpointFilterTests {
 				.extracting(WebAuthenticationDetails::getRemoteAddress)
 				.isEqualTo(REMOTE_ADDRESS);
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.FOUND.value());
-		assertThat(response.getRedirectedUrl()).isEqualTo("https://example.com?code=code&state=state");
+		assertThat(response.getRedirectedUrl()).isEqualTo("https://example.com?param=is%2Fencoded&code=code&state=previously%20encoded%2Fstate");
 	}
 
 	@Test
@@ -591,7 +591,7 @@ public class OAuth2AuthorizationEndpointFilterTests {
 		verifyNoInteractions(filterChain);
 
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.FOUND.value());
-		assertThat(response.getRedirectedUrl()).isEqualTo("https://example.com?code=code&state=state");
+		assertThat(response.getRedirectedUrl()).isEqualTo("https://example.com?code=code&state=previously%20encoded%2Fstate");
 	}
 
 	private void doFilterWhenAuthorizationRequestInvalidParameterThenError(RegisteredClient registeredClient,

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationEndpointFilterTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/OAuth2AuthorizationEndpointFilterTests.java
@@ -285,7 +285,7 @@ public class OAuth2AuthorizationEndpointFilterTests {
 				new OAuth2AuthorizationCodeRequestAuthenticationToken(
 						AUTHORIZATION_URI, registeredClient.getClientId(), principal,
 						registeredClient.getRedirectUris().iterator().next(), STATE, registeredClient.getScopes(), null);
-		OAuth2Error error = new OAuth2Error("errorCode", "errorDescription", "errorUri");
+		OAuth2Error error = new OAuth2Error("errorCode", "errorDescription", "errorUri#section");
 		when(this.authenticationManager.authenticate(any()))
 				.thenThrow(new OAuth2AuthorizationCodeRequestAuthenticationException(error, authorizationCodeRequestAuthentication));
 
@@ -299,7 +299,7 @@ public class OAuth2AuthorizationEndpointFilterTests {
 		verifyNoInteractions(filterChain);
 
 		assertThat(response.getStatus()).isEqualTo(HttpStatus.FOUND.value());
-		assertThat(response.getRedirectedUrl()).isEqualTo("https://example.com?error=errorCode&error_description=errorDescription&error_uri=errorUri&state=previously%20encoded%2Fstate");
+		assertThat(response.getRedirectedUrl()).isEqualTo("https://example.com?error=errorCode&error_description=errorDescription&error_uri=errorUri%23section&state=previously%20encoded%2Fstate");
 		assertThat(SecurityContextHolder.getContext().getAuthentication()).isSameAs(this.principal);
 	}
 

--- a/samples/custom-consent-authorizationserver/samples-custom-consent-authorizationserver.gradle
+++ b/samples/custom-consent-authorizationserver/samples-custom-consent-authorizationserver.gradle
@@ -8,6 +8,10 @@ group = project.rootProject.group
 version = project.rootProject.version
 sourceCompatibility = "17"
 
+test {
+	useJUnitPlatform()
+}
+
 repositories {
 	mavenCentral()
 	maven { url 'https://repo.spring.io/milestone' }

--- a/samples/custom-consent-authorizationserver/src/main/java/sample/config/AuthorizationServerConfig.java
+++ b/samples/custom-consent-authorizationserver/src/main/java/sample/config/AuthorizationServerConfig.java
@@ -93,6 +93,7 @@ public class AuthorizationServerConfig {
 				.authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
 				.authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
 				.redirectUri("http://127.0.0.1:8080/login/oauth2/code/messaging-client-oidc")
+				.redirectUri("http://127.0.0.1:8080/login/oauth2/code/messaging-client-oidc?param=is%2Fencoded")
 				.redirectUri("http://127.0.0.1:8080/authorized")
 				.scope(OidcScopes.OPENID)
 				.scope(OidcScopes.PROFILE)

--- a/samples/custom-consent-authorizationserver/src/test/java/sample/CustomConsentAuthorizationServerTests.java
+++ b/samples/custom-consent-authorizationserver/src/test/java/sample/CustomConsentAuthorizationServerTests.java
@@ -16,6 +16,9 @@
 package sample;
 
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,6 +39,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -58,15 +62,18 @@ public class CustomConsentAuthorizationServerTests {
 	@MockBean
 	private OAuth2AuthorizationConsentService authorizationConsentService;
 
-	private final String redirectUri = "http://127.0.0.1/login/oauth2/code/messaging-client-oidc";
+	private final String redirectUri = "http://127.0.0.1:8080/login/oauth2/code/messaging-client-oidc?param=is%2Fencoded";
+	public final String state = "some+%20encoded%2Fstate";
+	public final String reencodedState = "some%20%20encoded%2Fstate";
 
 	private final String authorizationRequestUri = UriComponentsBuilder
 			.fromPath("/oauth2/authorize")
 			.queryParam("response_type", "code")
 			.queryParam("client_id", "messaging-client")
 			.queryParam("scope", "openid message.read message.write")
-			.queryParam("state", "state")
-			.queryParam("redirect_uri", this.redirectUri)
+			.queryParam("state", this.state)
+			.queryParam("redirect_uri", URLEncoder.encode(this.redirectUri, StandardCharsets.UTF_8))
+			.build()
 			.toUriString();
 
 	@BeforeEach
@@ -75,6 +82,15 @@ public class CustomConsentAuthorizationServerTests {
 		this.webClient.getOptions().setRedirectEnabled(true);
 		this.webClient.getCookieManager().clearCookies();
 		when(this.authorizationConsentService.findById(any(), any())).thenReturn(null);
+	}
+
+	@Test
+	void authorizationRequestProperlyEncoded() {
+		UriComponents uriComponents = UriComponentsBuilder.fromUriString(authorizationRequestUri).build();
+
+		assertThat(uriComponents.getQueryParams().getFirst("state")).isEqualTo(state);
+		String redirectUri = uriComponents.getQueryParams().getFirst("redirect_uri");
+		assertThat(URLDecoder.decode(redirectUri, StandardCharsets.UTF_8)).isEqualTo(this.redirectUri);
 	}
 
 	@Test
@@ -105,6 +121,8 @@ public class CustomConsentAuthorizationServerTests {
 		String location = approveConsentResponse.getResponseHeaderValue("location");
 		assertThat(location).startsWith(this.redirectUri);
 		assertThat(location).contains("code=");
+		String state = UriComponentsBuilder.fromHttpUrl(location).build().getQueryParams().getFirst("state");
+		assertThat(state).isEqualTo(this.reencodedState);
 	}
 
 	@Test
@@ -121,6 +139,8 @@ public class CustomConsentAuthorizationServerTests {
 		String location = cancelConsentResponse.getResponseHeaderValue("location");
 		assertThat(location).startsWith(this.redirectUri);
 		assertThat(location).contains("error=access_denied");
+		String state = UriComponentsBuilder.fromHttpUrl(location).build().getQueryParams().getFirst("state");
+		assertThat(state).isEqualTo(this.reencodedState);
 	}
 
 }

--- a/samples/default-authorizationserver/samples-default-authorizationserver.gradle
+++ b/samples/default-authorizationserver/samples-default-authorizationserver.gradle
@@ -8,6 +8,10 @@ group = project.rootProject.group
 version = project.rootProject.version
 sourceCompatibility = "17"
 
+test {
+	useJUnitPlatform()
+}
+
 repositories {
 	mavenCentral()
 	maven { url 'https://repo.spring.io/milestone' }

--- a/samples/default-authorizationserver/src/main/java/sample/config/AuthorizationServerConfig.java
+++ b/samples/default-authorizationserver/src/main/java/sample/config/AuthorizationServerConfig.java
@@ -87,6 +87,7 @@ public class AuthorizationServerConfig {
 				.authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
 				.authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
 				.redirectUri("http://127.0.0.1:8080/login/oauth2/code/messaging-client-oidc")
+				.redirectUri("http://127.0.0.1:8080/login/oauth2/code/messaging-client-oidc?param=is%2Fencoded")
 				.redirectUri("http://127.0.0.1:8080/authorized")
 				.scope(OidcScopes.OPENID)
 				.scope(OidcScopes.PROFILE)


### PR DESCRIPTION
This fixes an issue with redirect URIs that already have URL-encoded parameters baked in.

I recently built an OIDC provider with Authorization Server for a client and noticed that some of their redirect URIs would cause problems.

PHP's Yii framework creates redirect URIs in the format `https://example.com/index.php?r=site%2Fauth&authclient=foo`. The authorization endpoint would reencode the `%2F` in the parameter to `%252F` and redirect users to a non-existing route.

This PR fixes the behavior while making sure that the encoding of the state parameter is unchanged.

Related to #875