### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -24,10 +24,10 @@ jobs:
         if: env.RUN_JOBS == 'true'
         run: |
           # Run jobs if in upstream repository
-          echo "::set-output name=runjobs::true"
+          echo "runjobs=true" >> $GITHUB_OUTPUT
           # Extract version from gradle.properties
           version=$(cat gradle.properties | grep "version=" | awk -F'=' '{print $2}')
-          echo "::set-output name=project_version::$version"
+          echo "project_version=$version" >> $GITHUB_OUTPUT
   build:
     name: Build
     needs: [prerequisites]


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Resolve  #1062 

Update `continuous-integration-workflow.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find .github/workflows -name '*.yml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
run: |
  # Run jobs if in upstream repository
  echo "::set-output name=runjobs::true"
  # Extract version from gradle.properties
  version=$(cat gradle.properties | grep "version=" | awk -F'=' '{print $2}')
  echo "::set-output name=project_version::$version"
```

**TO-BE**

```yml
run: |
  # Run jobs if in upstream repository
  echo "runjobs=true" >> $GITHUB_OUTPUT
  # Extract version from gradle.properties
  version=$(cat gradle.properties | grep "version=" | awk -F'=' '{print $2}')
  echo "project_version=$version" >> $GITHUB_OUTPUT
```
