### PR TITLE
Fix refresh token error code INVALID_CLIENT to INVALID_GRANT

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2RefreshTokenAuthenticationProvider.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2RefreshTokenAuthenticationProvider.java
@@ -111,7 +111,7 @@ public final class OAuth2RefreshTokenAuthenticationProvider implements Authentic
 		}
 
 		if (!registeredClient.getId().equals(authorization.getRegisteredClientId())) {
-			throw new OAuth2AuthenticationException(OAuth2ErrorCodes.INVALID_CLIENT);
+			throw new OAuth2AuthenticationException(OAuth2ErrorCodes.INVALID_GRANT);
 		}
 
 		if (!registeredClient.getAuthorizationGrantTypes().contains(AuthorizationGrantType.REFRESH_TOKEN)) {

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2RefreshTokenAuthenticationProviderTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2RefreshTokenAuthenticationProviderTests.java
@@ -400,7 +400,7 @@ public class OAuth2RefreshTokenAuthenticationProviderTests {
 				.isInstanceOf(OAuth2AuthenticationException.class)
 				.extracting(ex -> ((OAuth2AuthenticationException) ex).getError())
 				.extracting("errorCode")
-				.isEqualTo(OAuth2ErrorCodes.INVALID_CLIENT);
+				.isEqualTo(OAuth2ErrorCodes.INVALID_GRANT);
 	}
 
 	@Test


### PR DESCRIPTION
Hello.

We are trying to authenticate OIDC Basic OP Profile using your Spring-Authorization-Server library.

We encountered an issue where if another client requests token reissue.
It should return an 'invalid_grant' error, but instead, it returns an 'invalid_client' error.
(test fail log : https://www.certification.openid.net/log-detail.html?log=CrPyNh6RPaLJd05&public=true)

We looked through the official documentation and found that the 'invalid_grant' error should be returned when another client requests token reissue. Please refer to this link. -> https://www.rfc-editor.org/rfc/rfc6749#section-5.2

I would appreciate it if you could review it quickly and include it in the next version. Thank you!