### PR TITLE
fix: limit PKCE code verifier to authorization code grant_type

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/CodeVerifierAuthenticator.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/CodeVerifierAuthenticator.java
@@ -60,6 +60,9 @@ final class CodeVerifierAuthenticator {
 
 	void authenticateRequired(OAuth2ClientAuthenticationToken clientAuthentication,
 			RegisteredClient registeredClient) {
+		if (!authorizationCodeGrant(clientAuthentication.getAdditionalParameters())) {
+			return;
+		}
 		if (!authenticate(clientAuthentication, registeredClient)) {
 			throwInvalidGrant(PkceParameterNames.CODE_VERIFIER);
 		}
@@ -67,6 +70,9 @@ final class CodeVerifierAuthenticator {
 
 	void authenticateIfAvailable(OAuth2ClientAuthenticationToken clientAuthentication,
 			RegisteredClient registeredClient) {
+		if (!authorizationCodeGrant(clientAuthentication.getAdditionalParameters())) {
+			return;
+		}
 		authenticate(clientAuthentication, registeredClient);
 	}
 
@@ -74,9 +80,6 @@ final class CodeVerifierAuthenticator {
 			RegisteredClient registeredClient) {
 
 		Map<String, Object> parameters = clientAuthentication.getAdditionalParameters();
-		if (!authorizationCodeGrant(parameters)) {
-			return false;
-		}
 
 		OAuth2Authorization authorization = this.authorizationService.findByToken(
 				(String) parameters.get(OAuth2ParameterNames.CODE),


### PR DESCRIPTION
**Context**
Currently, the CodeVerifierAuthenticator checks the grant_type in the authenticate method, and returns false if the grant_type is not authorization_code. While this is fine for the authenticateIfAvailable method, this causes what I believe is incorrect behavior in authenticateRequired. My understanding is that the following is the desired the behavior of `authenticateRequired`:
```
If the grant_type is authorization_code, PKCE must be used and valid. If not, throw an exception. 
``` 

Currently, the behavior is as follows:
```
PKCE must be used and valid. If not, throw an exception. 
```

Since PKCE is only supported in the authorization_code flow, I believe the behavior defined above as desired behavior is what we want to happen. 


**Use case driving this change**
While it is not supported today by spring-authorization-server, we are starting to explore implementing functionality around issuing refresh tokens to a public client (a native iOS app, in our case). As we attempted to implement custom functionality to PoC supporting this, we realized that this current implementation is attempting to enforce PKCE for public clients on the refresh_token grant type - throwing an exception because authenticate returns false because the grant_type is not auth code. This PR is not intended to get down the rabbit hole of full implementation for public clients of access to refresh tokens. It's simply intended to restrict the PKCE-required validation for public clients to the grant_type it is intended for - authorization_code. 