### PR TITLE
Add logout success page to default client sample

### DIFF
--- a/samples/default-authorizationserver/src/main/java/sample/config/AuthorizationServerConfig.java
+++ b/samples/default-authorizationserver/src/main/java/sample/config/AuthorizationServerConfig.java
@@ -54,6 +54,7 @@ import org.springframework.security.web.authentication.LoginUrlAuthenticationEnt
 
 /**
  * @author Joe Grandja
+ * @author Dmitriy Dubson
  * @since 0.0.1
  */
 @Configuration(proxyBeanMethods = false)
@@ -88,7 +89,7 @@ public class AuthorizationServerConfig {
 				.authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
 				.redirectUri("http://127.0.0.1:8080/login/oauth2/code/messaging-client-oidc")
 				.redirectUri("http://127.0.0.1:8080/authorized")
-				.postLogoutRedirectUri("http://127.0.0.1:8080/index")
+				.postLogoutRedirectUri("http://127.0.0.1:8080/logged-out")
 				.scope(OidcScopes.OPENID)
 				.scope(OidcScopes.PROFILE)
 				.scope("message.read")

--- a/samples/messages-client/src/main/java/sample/config/SecurityConfig.java
+++ b/samples/messages-client/src/main/java/sample/config/SecurityConfig.java
@@ -30,6 +30,7 @@ import static org.springframework.security.config.Customizer.withDefaults;
 
 /**
  * @author Joe Grandja
+ * @author Dmitriy Dubson
  * @since 0.0.1
  */
 @EnableWebSecurity
@@ -49,7 +50,9 @@ public class SecurityConfig {
 	SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http
 			.authorizeHttpRequests(authorize ->
-				authorize.anyRequest().authenticated()
+				authorize
+					.requestMatchers("/logged-out").permitAll()
+					.anyRequest().authenticated()
 			)
 			.oauth2Login(oauth2Login ->
 				oauth2Login.loginPage("/oauth2/authorization/messaging-client-oidc"))
@@ -66,7 +69,7 @@ public class SecurityConfig {
 
 		// Set the location that the End-User's User Agent will be redirected to
 		// after the logout has been performed at the Provider
-		oidcLogoutSuccessHandler.setPostLogoutRedirectUri("{baseUrl}/index");
+		oidcLogoutSuccessHandler.setPostLogoutRedirectUri("{baseUrl}/logged-out");
 
 		return oidcLogoutSuccessHandler;
 	}

--- a/samples/messages-client/src/main/java/sample/web/DefaultController.java
+++ b/samples/messages-client/src/main/java/sample/web/DefaultController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 /**
  * @author Joe Grandja
+ * @author Dmitriy Dubson
  * @since 0.0.1
  */
 @Controller
@@ -34,4 +35,10 @@ public class DefaultController {
 	public String index() {
 		return "index";
 	}
+
+	@GetMapping("/logged-out")
+	public String loggedOut() {
+		return "logged-out";
+	}
+
 }

--- a/samples/messages-client/src/main/resources/templates/logged-out.html
+++ b/samples/messages-client/src/main/resources/templates/logged-out.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
+<head>
+	<title>Spring Security OAuth 2.0 Sample</title>
+	<meta charset="utf-8"/>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+	<link rel="stylesheet" href="/webjars/bootstrap/css/bootstrap.css"
+		  th:href="@{/webjars/bootstrap/css/bootstrap.css}"/>
+</head>
+<body>
+<div th:fragment="header">
+	<nav class="navbar navbar-default"></nav>
+</div>
+<div class="container">
+	<h1>You are now logged out.</h1>
+	<a href="/" th:href="@{/}">Go back home</a>
+</div>
+<script src="/webjars/jquery/jquery.min.js" th:src="@{/webjars/jquery/jquery.min.js}"></script>
+<script src="/webjars/bootstrap/js/bootstrap.min.js" th:src="@{/webjars/bootstrap/js/bootstrap.min.js}"></script>
+</body>
+</html>


### PR DESCRIPTION
Sample client (located in 'samples/messages-client' directory) is configured with a custom logout success page where the end-user is redirected to upon successful logout action.

Logout flow tested with:
- `samples/default-athorizationserver`
- `samples/messages-client`
- `samples/messages-resource`

Fixes gh-1142