### PR TITLE
Dedicated authentication-handler #WiP

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2TokenEndpointFilter.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2TokenEndpointFilter.java
@@ -27,14 +27,12 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.core.log.LogMessage;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -44,7 +42,6 @@ import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.core.http.converter.OAuth2AccessTokenResponseHttpMessageConverter;
-import org.springframework.security.oauth2.core.http.converter.OAuth2ErrorHttpMessageConverter;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2AccessTokenAuthenticationToken;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2AuthorizationCodeAuthenticationProvider;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2AuthorizationGrantAuthenticationToken;
@@ -56,6 +53,7 @@ import org.springframework.security.oauth2.server.authorization.web.authenticati
 import org.springframework.security.oauth2.server.authorization.web.authentication.OAuth2ClientCredentialsAuthenticationConverter;
 import org.springframework.security.oauth2.server.authorization.web.authentication.OAuth2DeviceCodeAuthenticationConverter;
 import org.springframework.security.oauth2.server.authorization.web.authentication.OAuth2RefreshTokenAuthenticationConverter;
+import org.springframework.security.oauth2.server.authorization.web.authentication.handler.OAuth2TokenEndpointFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationConverter;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
@@ -107,13 +105,11 @@ public final class OAuth2TokenEndpointFilter extends OncePerRequestFilter {
 	private final RequestMatcher tokenEndpointMatcher;
 	private final HttpMessageConverter<OAuth2AccessTokenResponse> accessTokenHttpResponseConverter =
 			new OAuth2AccessTokenResponseHttpMessageConverter();
-	private final HttpMessageConverter<OAuth2Error> errorHttpResponseConverter =
-			new OAuth2ErrorHttpMessageConverter();
 	private AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource =
 			new WebAuthenticationDetailsSource();
 	private AuthenticationConverter authenticationConverter;
 	private AuthenticationSuccessHandler authenticationSuccessHandler = this::sendAccessTokenResponse;
-	private AuthenticationFailureHandler authenticationFailureHandler = this::sendErrorResponse;
+	private AuthenticationFailureHandler authenticationFailureHandler = new OAuth2TokenEndpointFailureHandler();
 
 	/**
 	 * Constructs an {@code OAuth2TokenEndpointFilter} using the provided parameters.
@@ -248,15 +244,6 @@ public final class OAuth2TokenEndpointFilter extends OncePerRequestFilter {
 		OAuth2AccessTokenResponse accessTokenResponse = builder.build();
 		ServletServerHttpResponse httpResponse = new ServletServerHttpResponse(response);
 		this.accessTokenHttpResponseConverter.write(accessTokenResponse, null, httpResponse);
-	}
-
-	private void sendErrorResponse(HttpServletRequest request, HttpServletResponse response,
-			AuthenticationException exception) throws IOException {
-
-		OAuth2Error error = ((OAuth2AuthenticationException) exception).getError();
-		ServletServerHttpResponse httpResponse = new ServletServerHttpResponse(response);
-		httpResponse.setStatusCode(HttpStatus.BAD_REQUEST);
-		this.errorHttpResponseConverter.write(error, null, httpResponse);
 	}
 
 	private static void throwError(String errorCode, String parameterName) {

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/authentication/handler/OAuth2TokenEndpointFailureHandler.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/authentication/handler/OAuth2TokenEndpointFailureHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization.web.authentication.handler;
+
+import java.io.IOException;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.http.converter.OAuth2ErrorHttpMessageConverter;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+public class OAuth2TokenEndpointFailureHandler implements AuthenticationFailureHandler {
+
+	private final HttpMessageConverter<OAuth2Error> errorHttpResponseConverter =
+			new OAuth2ErrorHttpMessageConverter();
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+			AuthenticationException exception) throws IOException, ServletException {
+				OAuth2Error error = ((OAuth2AuthenticationException) exception).getError();
+		ServletServerHttpResponse httpResponse = new ServletServerHttpResponse(response);
+		httpResponse.setStatusCode(HttpStatus.BAD_REQUEST);
+		this.errorHttpResponseConverter.write(error, null, httpResponse);
+	}
+}


### PR DESCRIPTION
Hi spring-authorization-server gurus,

I'm probably holding it wrong, but here goes :)

My use-case is pretty straight-forward; add ["security logging"](https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/) as recommended by OWASP.

I've looked into the authorization-server, but didn't find logging-support that matches the recommendation - my apologies if I've missed the support.

So I've created this non-exhaustive draft to demonstrate one possible approach supporting my use-case.

**Expected Behavior**

Augmenting framework error-/success-handling is a 1st class citizen.

Ex. based on the drafted approach I would be able to provide my own authentication-handler ala.

```
...

class MyOAuth2TokenEndpointFailureHandler implements AuthenticationFailureHandler {

    OAuth2TokenEndpointFailureHandler delegate = new OAuth2TokenEndpointFailureHandler()

    @Override
    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
        AuthenticationException exception) throws IOException, ServletException {

        MySecurityLogger.log(request, response, exception);

        delegate.onAuthenticationFailure(request, response, exception);
    }
}
```

```
OAuth2TokenEndpointFilter#setAuthenticationFailureHandler(new MyOAuth2TokenEndpointFailureHandler())
```

As demonstrated above, this approach would support augmenting without duplicating code from the framework.

I suggest this change, from private method to dedicated class, is applied to all filter authentication-handlers - as that would support any append/augment use-case I can think of 🤓

If this approach is acceptable I would be happy to take a stab at refactoring.

**Current Behavior**

Currently each authentication-handler implemented by the framework is encapsulated in the class in a private method unfit for reuse.

**Context**

 > How has this issue affected you?

In-order to augment the endpoint filters, I've accumulated an undesired responsibility for maintaining a mirror of the default authentication-handlers implementation.

> What are you trying to accomplish?

Augment framework behavior, optimally by appending a bit of custom configuration/code - without changing the core-behavior.

> What other alternatives have you considered? 

Undoing the private encapsulation at runtime via reflection, but rejected the approach as it's brittle & time-consuming.

> Are you aware of any workarounds?

Unfortunately no :/