### PR TITLE
Replaces 'install' with 'publishToMavenLocal' command in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -66,7 +66,7 @@ git clone git@github.com:spring-projects/spring-authorization-server.git
 === Install all spring-\* jars into your local Maven cache
 [indent=0]
 ----
-./gradlew install
+./gradlew publishToMavenLocal
 ----
 
 === Compile and test; build all jars, distribution zips, and docs


### PR DESCRIPTION
Fixes #1298 