### PR TITLE
Fix: add length validation to prevent 500 error on invalid usercode

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/authentication/OAuth2DeviceAuthorizationConsentAuthenticationConverter.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/authentication/OAuth2DeviceAuthorizationConsentAuthenticationConverter.java
@@ -80,7 +80,7 @@ public final class OAuth2DeviceAuthorizationConsentAuthenticationConverter imple
 
 		// user_code (REQUIRED)
 		String userCode = parameters.getFirst(OAuth2ParameterNames.USER_CODE);
-		if (!StringUtils.hasText(userCode) ||
+		if (!OAuth2EndpointUtils.validateUserCode(userCode) ||
 				parameters.get(OAuth2ParameterNames.USER_CODE).size() != 1) {
 			OAuth2EndpointUtils.throwError(
 					OAuth2ErrorCodes.INVALID_REQUEST,

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/authentication/OAuth2DeviceVerificationAuthenticationConverter.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/authentication/OAuth2DeviceVerificationAuthenticationConverter.java
@@ -30,7 +30,6 @@ import org.springframework.security.oauth2.server.authorization.authentication.O
 import org.springframework.security.oauth2.server.authorization.web.OAuth2DeviceVerificationEndpointFilter;
 import org.springframework.security.web.authentication.AuthenticationConverter;
 import org.springframework.util.MultiValueMap;
-import org.springframework.util.StringUtils;
 
 /**
  * Attempts to extract a user code from {@link HttpServletRequest} for the
@@ -49,7 +48,6 @@ public final class OAuth2DeviceVerificationAuthenticationConverter implements Au
 	private static final String ERROR_URI = "https://datatracker.ietf.org/doc/html/rfc6749#section-5.2";
 	private static final Authentication ANONYMOUS_AUTHENTICATION = new AnonymousAuthenticationToken(
 			"anonymous", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS"));
-
 	@Override
 	public Authentication convert(HttpServletRequest request) {
 		if (!("GET".equals(request.getMethod()) || "POST".equals(request.getMethod()))) {
@@ -64,7 +62,7 @@ public final class OAuth2DeviceVerificationAuthenticationConverter implements Au
 
 		// user_code (REQUIRED)
 		String userCode = parameters.getFirst(OAuth2ParameterNames.USER_CODE);
-		if (!StringUtils.hasText(userCode) ||
+		if (!OAuth2EndpointUtils.validateUserCode(userCode) ||
 				parameters.get(OAuth2ParameterNames.USER_CODE).size() != 1) {
 			OAuth2EndpointUtils.throwError(
 					OAuth2ErrorCodes.INVALID_REQUEST,

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/authentication/OAuth2EndpointUtils.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/authentication/OAuth2EndpointUtils.java
@@ -94,7 +94,8 @@ final class OAuth2EndpointUtils {
 		sb.insert(4, '-');
 		return sb.toString();
 	}
-	static boolean validateUserCode(String userCode){
-		return userCode != null && userCode.replaceAll("[^A-Z\\d]+", "").length() == 8;
+
+	static boolean validateUserCode(String userCode) {
+		return userCode != null && userCode.toUpperCase().replaceAll("[^A-Z\\d]+", "").length() == 8;
 	}
 }

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/authentication/OAuth2EndpointUtils.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/authentication/OAuth2EndpointUtils.java
@@ -94,5 +94,7 @@ final class OAuth2EndpointUtils {
 		sb.insert(4, '-');
 		return sb.toString();
 	}
-
+	static boolean validateUserCode(String userCode){
+		return userCode != null && userCode.replaceAll("[^A-Z\\d]+", "").length() == 8;
+	}
 }

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/authentication/OAuth2DeviceAuthorizationConsentAuthenticationConverterTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/authentication/OAuth2DeviceAuthorizationConsentAuthenticationConverterTests.java
@@ -148,6 +148,22 @@ public class OAuth2DeviceAuthorizationConsentAuthenticationConverterTests {
 	}
 
 	@Test
+	public void convertWhenInvalidUserCodeThenInvalidRequestError() {
+		MockHttpServletRequest request = createRequest();
+		request.addParameter(OAuth2ParameterNames.STATE, STATE);
+		request.addParameter(OAuth2ParameterNames.CLIENT_ID, CLIENT_ID);
+		request.addParameter(OAuth2ParameterNames.USER_CODE, "LONG-USER-CODE");
+		// @formatter:off
+		assertThatExceptionOfType(OAuth2AuthenticationException.class)
+				.isThrownBy(() -> this.converter.convert(request))
+				.withMessageContaining(OAuth2ParameterNames.USER_CODE)
+				.extracting(OAuth2AuthenticationException::getError)
+				.extracting(OAuth2Error::getErrorCode)
+				.isEqualTo(OAuth2ErrorCodes.INVALID_REQUEST);
+		// @formatter:on
+	}
+
+	@Test
 	public void convertWhenMultipleUserCodeParametersThenInvalidRequestError() {
 		MockHttpServletRequest request = createRequest();
 		request.addParameter(OAuth2ParameterNames.STATE, STATE);

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/authentication/OAuth2DeviceVerificationAuthenticationConverterTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/authentication/OAuth2DeviceVerificationAuthenticationConverterTests.java
@@ -107,6 +107,7 @@ public class OAuth2DeviceVerificationAuthenticationConverterTests {
 				.isEqualTo(OAuth2ErrorCodes.INVALID_REQUEST);
 		// @formatter:on
 	}
+
 	@Test
 	public void convertWhenMultipleUserCodeParameterThenInvalidRequestError() {
 		MockHttpServletRequest request = createRequest();

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/authentication/OAuth2DeviceVerificationAuthenticationConverterTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/authentication/OAuth2DeviceVerificationAuthenticationConverterTests.java
@@ -95,6 +95,19 @@ public class OAuth2DeviceVerificationAuthenticationConverterTests {
 	}
 
 	@Test
+	public void convertWhenInvalidUserCodeParameterThenInvalidRequestError() {
+		MockHttpServletRequest request = createRequest();
+		request.addParameter(OAuth2ParameterNames.USER_CODE, "LONG-USER-CODE");
+		// @formatter:off
+		assertThatExceptionOfType(OAuth2AuthenticationException.class)
+				.isThrownBy(() -> this.converter.convert(request))
+				.withMessageContaining(OAuth2ParameterNames.USER_CODE)
+				.extracting(OAuth2AuthenticationException::getError)
+				.extracting(OAuth2Error::getErrorCode)
+				.isEqualTo(OAuth2ErrorCodes.INVALID_REQUEST);
+		// @formatter:on
+	}
+	@Test
 	public void convertWhenMultipleUserCodeParameterThenInvalidRequestError() {
 		MockHttpServletRequest request = createRequest();
 		request.addParameter(OAuth2ParameterNames.USER_CODE, USER_CODE);


### PR DESCRIPTION
Hi SAS team!
Currently, a non empty, invalid usercode results in a 500 error as the assertion in the normalizeUserCode method fails.
