### PR TITLE
Add Revved up by Gradle Enterprise badge

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,8 @@
 image::https://badges.gitter.im/Join%20Chat.svg[Gitter,link=https://gitter.im/spring-projects/spring-security?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge]
 
-image:https://github.com/spring-projects/spring-authorization-server/workflows/CI/badge.svg?branch=main["Build Status", link="https://github.com/spring-projects/spring-authorization-server/actions?query=workflow%3ACI"]
+image::https://github.com/spring-projects/spring-authorization-server/workflows/CI/badge.svg?branch=main["Build Status", link="https://github.com/spring-projects/spring-authorization-server/actions?query=workflow%3ACI"]
+
+image::https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A["Revved up by Gradle Enterprise", link="https://ge.spring.io/scans?&search.rootProjectNames=spring-authorization-server"]
 
 = Spring Authorization Server
 


### PR DESCRIPTION
This pull request adds the Revved up by Gradle Enterprise badge to the top of the README.

[![image](https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.spring.io/scans?&search.rootProjectNames=spring-authorization-server)

This badge is already present on [Spring Boot](https://github.com/spring-projects/spring-boot#readme), [Spring Framework](https://github.com/spring-projects/spring-framework#readme), and [Spring Security](https://github.com/spring-projects/spring-security#readme).