### PR TITLE
Follow RFC to allow client_secret to be empty string

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/authentication/ClientSecretPostAuthenticationConverter.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/authentication/ClientSecretPostAuthenticationConverter.java
@@ -61,9 +61,6 @@ public final class ClientSecretPostAuthenticationConverter implements Authentica
 
 		// client_secret (REQUIRED)
 		String clientSecret = parameters.getFirst(OAuth2ParameterNames.CLIENT_SECRET);
-		if (!StringUtils.hasText(clientSecret)) {
-			return null;
-		}
 
 		if (parameters.get(OAuth2ParameterNames.CLIENT_SECRET).size() != 1) {
 			throw new OAuth2AuthenticationException(OAuth2ErrorCodes.INVALID_REQUEST);


### PR DESCRIPTION
Hi thanks for the authorization server! I am seeing an edge case here: My app originally communicates with Keycloak, and now I am migrating to Spring authorization server. The app has configured an empty client_secret (I do not fill in a strong password, because any "secret" in an app can be reverse engineered so is not a real "secret"). It worked well when sending requests (e.g. login) to Keycloak, but gives errors in Spring Auth Server.

After debugging, it seems that, if I choose a non-empty client secret, it works. I checked https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1 (linked from ClientSecretPostAuthenticationConverter), as well as https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-08#section-2.4.1 (oauth 2.1). They say it is "required" but not say it is "nonempty". Indeed, oauth 2.0 says, "The client MAY omit the parameter if the client secret is an empty string", so I guess the RFC does allow an empty string.