### PR TITLE
Fix NPE during token introspection.

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2TokenIntrospectionAuthenticationProvider.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2TokenIntrospectionAuthenticationProvider.java
@@ -98,7 +98,7 @@ public final class OAuth2TokenIntrospectionAuthenticationProvider implements Aut
 
 		OAuth2Authorization.Token<OAuth2Token> authorizedToken =
 				authorization.getToken(tokenIntrospectionAuthentication.getToken());
-		if (!authorizedToken.isActive()) {
+		if (authorizedToken == null || !authorizedToken.isActive()) {
 			if (this.logger.isTraceEnabled()) {
 				this.logger.trace("Did not introspect token since not active");
 			}


### PR DESCRIPTION
In our implementation of `OAuth2AuthorizationService` when an access token has been refreshed, the `OAuth2Authorization` can still be retrieved from the data source by passing the stale access token value into `findByToken(...)`. This is because we retain the stale access tokens in our data store, and the relationship to the original authorization is maintained.

This can cause a NPE in the `OAuth2TokenIntrospectionAuthenticationProvider` when inspecting the stale token, as the initial lookup by value (i.e. `findByToken(...)`) will retrieve the `OAuth2Authorization`. However, the call to `authorization.getToken(tokenIntrospectionAuthentication.getToken())` returns null for `authorizedToken`, because the stale token value is no longer the active access token associated with the authorization.

This PR fixes the issue by performing a null check on `authorizedToken` before checking `authorizedToken.isActive()`.