### PR TITLE
Make CodeVerifierAuthenticator public

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/CodeVerifierAuthenticator.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/CodeVerifierAuthenticator.java
@@ -49,7 +49,7 @@ import org.springframework.util.StringUtils;
  * @see OAuth2ClientAuthenticationToken
  * @see OAuth2AuthorizationService
  */
-final class CodeVerifierAuthenticator {
+public final class CodeVerifierAuthenticator {
 	private static final OAuth2TokenType AUTHORIZATION_CODE_TOKEN_TYPE = new OAuth2TokenType(OAuth2ParameterNames.CODE);
 	private final Log logger = LogFactory.getLog(getClass());
 	private final OAuth2AuthorizationService authorizationService;


### PR DESCRIPTION
* Make the CodeVerifierAuthenticator public, so it can be reused in custom authentication providers.