### PR TITLE
Add setCustomizer method to DelegatingOAuth2TokenGenerator

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/token/DelegatingOAuth2TokenGenerator.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/token/DelegatingOAuth2TokenGenerator.java
@@ -32,10 +32,10 @@ import org.springframework.util.Assert;
  * with the first {@code non-null} {@link OAuth2Token} being returned.
  *
  * @author Joe Grandja
- * @since 0.2.3
  * @see OAuth2TokenGenerator
  * @see JwtGenerator
  * @see OAuth2RefreshTokenGenerator
+ * @since 0.2.3
  */
 public final class DelegatingOAuth2TokenGenerator implements OAuth2TokenGenerator<OAuth2Token> {
 	private final List<OAuth2TokenGenerator<OAuth2Token>> tokenGenerators;
@@ -62,6 +62,19 @@ public final class DelegatingOAuth2TokenGenerator implements OAuth2TokenGenerato
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Set customizer to {@code OAuth2TokenGenerator} in tokenGenerators.
+	 *
+	 * @param customizer Customizer of {@link OAuth2TokenCustomizer}
+	 */
+	public void setCustomizer(OAuth2TokenCustomizer<OAuth2TokenClaimsContext> customizer) {
+		for (OAuth2TokenGenerator<?> tokenGenerator : this.tokenGenerators) {
+			if (tokenGenerator instanceof OAuth2AccessTokenGenerator) {
+				((OAuth2AccessTokenGenerator) tokenGenerator).setAccessTokenCustomizer(customizer);
+			}
+		}
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Hello! While using the Spring Authorization server library, I encountered an inconvenience. The OAuth2AccessTokenGenerator allows us to inject an implementation class of OAuth2TokenCustomizer through its setAccessTokenCustomizer method. However, this functionality is not available for an OAuth2AccessTokenGenerator that is constructor-injected into a DelegatingOAuth2TokenGenerator. This limitation makes it difficult to add additional information to the Access token during the authentication process when using the DelegatingOAuth2TokenGenerator class.

To resolve this issue, I have added a setCustomizer method to the DelegatingOAuth2TokenGenerator, allowing dynamic configuration of the Customizer from classes implementing the AuthenticationProvider. I am currently using this functionality in my project and can provide an example if needed. If there is a reason this function cannot be added, please let me know. Thank you!