### PR TITLE
Adds paramater name to JwtClientAssertion validation error Fixes gh-1449

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/authentication/JwtClientAssertionAuthenticationConverter.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/authentication/JwtClientAssertionAuthenticationConverter.java
@@ -23,6 +23,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientAuthenticationToken;
@@ -58,7 +59,7 @@ public final class JwtClientAssertionAuthenticationConverter implements Authenti
 		// client_assertion_type (REQUIRED)
 		String clientAssertionType = parameters.getFirst(OAuth2ParameterNames.CLIENT_ASSERTION_TYPE);
 		if (parameters.get(OAuth2ParameterNames.CLIENT_ASSERTION_TYPE).size() != 1) {
-			throw new OAuth2AuthenticationException(OAuth2ErrorCodes.INVALID_REQUEST);
+			throwException(OAuth2ParameterNames.CLIENT_ASSERTION_TYPE);
 		}
 		if (!JWT_CLIENT_ASSERTION_AUTHENTICATION_METHOD.getValue().equals(clientAssertionType)) {
 			return null;
@@ -67,14 +68,14 @@ public final class JwtClientAssertionAuthenticationConverter implements Authenti
 		// client_assertion (REQUIRED)
 		String jwtAssertion = parameters.getFirst(OAuth2ParameterNames.CLIENT_ASSERTION);
 		if (parameters.get(OAuth2ParameterNames.CLIENT_ASSERTION).size() != 1) {
-			throw new OAuth2AuthenticationException(OAuth2ErrorCodes.INVALID_REQUEST);
+			throwException(OAuth2ParameterNames.CLIENT_ASSERTION);
 		}
 
 		// client_id (OPTIONAL as per specification but REQUIRED by this implementation)
 		String clientId = parameters.getFirst(OAuth2ParameterNames.CLIENT_ID);
 		if (!StringUtils.hasText(clientId) ||
 				parameters.get(OAuth2ParameterNames.CLIENT_ID).size() != 1) {
-			throw new OAuth2AuthenticationException(OAuth2ErrorCodes.INVALID_REQUEST);
+			throwException(OAuth2ParameterNames.CLIENT_ID);
 		}
 
 		Map<String, Object> additionalParameters = OAuth2EndpointUtils.getParametersIfMatchesAuthorizationCodeGrantRequest(request,
@@ -84,6 +85,10 @@ public final class JwtClientAssertionAuthenticationConverter implements Authenti
 
 		return new OAuth2ClientAuthenticationToken(clientId, JWT_CLIENT_ASSERTION_AUTHENTICATION_METHOD,
 				jwtAssertion, additionalParameters);
+	}
+
+	public void throwException(String parameterName) {
+		throw new OAuth2AuthenticationException(new OAuth2Error(OAuth2ErrorCodes.INVALID_REQUEST), "Required parameter %s is missing or invalid".formatted(parameterName));
 	}
 
 }

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/authentication/JwtClientAssertionAuthenticationConverterTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/authentication/JwtClientAssertionAuthenticationConverterTests.java
@@ -60,7 +60,7 @@ public class JwtClientAssertionAuthenticationConverterTests {
 		request.addParameter(OAuth2ParameterNames.CLIENT_ASSERTION_TYPE, JWT_BEARER_TYPE);
 		request.addParameter(OAuth2ParameterNames.CLIENT_ASSERTION_TYPE, "other-client-assertion-type");
 		request.addParameter(OAuth2ParameterNames.CLIENT_ASSERTION, "jwt-assertion");
-		assertThrown(request, OAuth2ErrorCodes.INVALID_REQUEST);
+		assertThrown(request, OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ParameterNames.CLIENT_ASSERTION_TYPE);
 	}
 
 	@Test
@@ -78,7 +78,7 @@ public class JwtClientAssertionAuthenticationConverterTests {
 		request.addParameter(OAuth2ParameterNames.CLIENT_ASSERTION_TYPE, JWT_BEARER_TYPE);
 		request.addParameter(OAuth2ParameterNames.CLIENT_ASSERTION, "jwt-assertion");
 		request.addParameter(OAuth2ParameterNames.CLIENT_ASSERTION, "other-jwt-assertion");
-		assertThrown(request, OAuth2ErrorCodes.INVALID_REQUEST);
+		assertThrown(request, OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ParameterNames.CLIENT_ASSERTION);
 	}
 
 	@Test
@@ -86,7 +86,7 @@ public class JwtClientAssertionAuthenticationConverterTests {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addParameter(OAuth2ParameterNames.CLIENT_ASSERTION_TYPE, JWT_BEARER_TYPE);
 		request.addParameter(OAuth2ParameterNames.CLIENT_ASSERTION, "jwt-assertion");
-		assertThrown(request, OAuth2ErrorCodes.INVALID_REQUEST);
+		assertThrown(request, OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ParameterNames.CLIENT_ID);
 	}
 
 	@Test
@@ -96,7 +96,7 @@ public class JwtClientAssertionAuthenticationConverterTests {
 		request.addParameter(OAuth2ParameterNames.CLIENT_ASSERTION, "jwt-assertion");
 		request.addParameter(OAuth2ParameterNames.CLIENT_ID, "client-1");
 		request.addParameter(OAuth2ParameterNames.CLIENT_ID, "client-2");
-		assertThrown(request, OAuth2ErrorCodes.INVALID_REQUEST);
+		assertThrown(request, OAuth2ErrorCodes.INVALID_REQUEST, OAuth2ParameterNames.CLIENT_ID);
 	}
 
 	@Test
@@ -121,9 +121,10 @@ public class JwtClientAssertionAuthenticationConverterTests {
 						entry("custom-param-2", new String[] {"custom-value-1", "custom-value-2"}));
 	}
 
-	private void assertThrown(MockHttpServletRequest request, String errorCode) {
+	private void assertThrown(MockHttpServletRequest request, String errorCode, String parameter) {
 		assertThatThrownBy(() -> this.converter.convert(request))
 				.isInstanceOf(OAuth2AuthenticationException.class)
+				.hasMessageContaining(parameter)
 				.extracting(ex -> ((OAuth2AuthenticationException) ex).getError())
 				.extracting("errorCode")
 				.isEqualTo(errorCode);


### PR DESCRIPTION
The validation could be re-written to validate all parameters and add the name of all invalid parameters, however, this change is more minimal as it only requires a small refactor of the existing code.