### PR TITLE
Build directories are excluded from the checkstyleNohttp task

### DIFF
--- a/buildSrc/src/main/java/org/springframework/gradle/nohttp/SpringNoHttpPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/gradle/nohttp/SpringNoHttpPlugin.java
@@ -36,6 +36,6 @@ public class SpringNoHttpPlugin implements Plugin<Project> {
 		NoHttpExtension nohttp = project.getExtensions().getByType(NoHttpExtension.class);
 		File allowlistFile = project.getRootProject().file("etc/nohttp/allowlist.lines");
 		nohttp.setAllowlistFile(allowlistFile);
-		nohttp.getSource().exclude("buildSrc/build/**");
+		nohttp.getSource().exclude("**/build/**");
 	}
 }


### PR DESCRIPTION
This change addresses a build deprecation warning causing caching to be disabled for the `checkstyleNohttp`. The deprecation warning is caused by [the `checkstyleNohttp` task using the output files of other tasks, without creating an implicit or explicit dependency between them](https://ge.solutions-team.gradle.com/s/5kw3tind56qii/deprecations). As a result, [Gradle disables caching in order to ensure correctness of the build](https://ge.solutions-team.gradle.com/s/5kw3tind56qii/timeline?details=z56sfccjdrmfs).

With this change, the `checkstyleNohttp` task will ignore all build directories. This [resolves the deprecation warnings](https://ge.solutions-team.gradle.com/s/drhuxrwqyxb7c/deprecations) and [allows the task to be cached](https://ge.solutions-team.gradle.com/s/drhuxrwqyxb7c/timeline?details=z56sfccjdrmfs).