### PR TITLE
Explain the importance of requireProofKey

### DIFF
--- a/docs/modules/ROOT/pages/guides/how-to-pkce.adoc
+++ b/docs/modules/ROOT/pages/guides/how-to-pkce.adoc
@@ -58,7 +58,7 @@ include::{examples-dir}/main/java/sample/pkce/ClientConfig.java[tag=client,inden
 ----
 ======
 
-NOTE: The `requireProofKey` setting is helpful in situations where you forget to include the `code_challenge` and `code_challenge_method` query parameters because you will receive an error indicating PKCE is required during the xref:protocol-endpoints.adoc#oauth2-authorization-endpoint[Authorization Request] instead of a general client authentication error during the xref:protocol-endpoints.adoc#oauth2-token-endpoint[Token Request].
+NOTE: The `requireProofKey` setting is important to avoid the https://www.ietf.org/archive/id/draft-ietf-oauth-security-topics-22.html#name-pkce-downgrade-attack[PKCE Downgrade Attack^]. Set it to true if your clients are using PCKE.
 
 [[authenticate-with-client]]
 == Authenticate with the Client


### PR DESCRIPTION
The importance of making PKCE required is explained at https://www.ietf.org/archive/id/draft-ietf-oauth-security-topics-22.html#name-pkce-downgrade-attack