### PR TITLE
Update Enterprise Gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -5,8 +5,8 @@ pluginManagement {
 }
 
 plugins {
-	id "com.gradle.enterprise" version "3.13.3"
-	id "io.spring.ge.conventions" version "0.0.13"
+	id "com.gradle.enterprise" version "3.16.2"
+	id "io.spring.ge.conventions" version "0.0.15"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
# Update Enterprise Gradle

## Bumps
- [com.gradle.enterprise](https://plugins.gradle.org/plugin/com.gradle.enterprise) from 3.13.3 to 3.16.2
- [io.spring.ge.conventions](https://github.com/spring-io/gradle-enterprise-conventions) from 0.0.13 to 0.0.15

## Compatibility
Based on commits in spring-framework repo, internally spring team should support latest Gradle Enterprise plugin:
- Commit with note that only 3.15 version is supported: spring-projects/spring-framework@e3f185a696b0d6ca017a83366f24ed692573d14e 
- Commit by @sbrannen with 3.16 version: spring-projects/spring-framework@b7e4fa16cae5f5a45fd661c51d558c8b9e5c39ae