### PR TITLE
Provide more flexibility on when to display consent page

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeRequestAuthenticationContext.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeRequestAuthenticationContext.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import org.springframework.lang.Nullable;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsent;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.util.Assert;
 
@@ -64,6 +66,27 @@ public final class OAuth2AuthorizationCodeRequestAuthenticationContext implement
 	}
 
 	/**
+	 * Returns the {@link OAuth2AuthorizationRequest oauth2 authorization request}.
+	 *
+	 * @return the {@link OAuth2AuthorizationRequest}
+	 */
+	@Nullable
+	public OAuth2AuthorizationRequest getOAuth2AuthorizationRequest() {
+		return get(OAuth2AuthorizationRequest.class);
+	}
+
+	/**
+	 * Returns the {@link OAuth2AuthorizationConsent oauth2 authorization consent}.
+	 *
+	 * @return the {@link OAuth2AuthorizationConsent}
+	 */
+	@Nullable
+	public OAuth2AuthorizationConsent getOAuth2AuthorizationConsent() {
+		return get(OAuth2AuthorizationConsent.class);
+	}
+
+
+	/**
 	 * Constructs a new {@link Builder} with the provided {@link OAuth2AuthorizationCodeRequestAuthenticationToken}.
 	 *
 	 * @param authentication the {@link OAuth2AuthorizationCodeRequestAuthenticationToken}
@@ -90,6 +113,28 @@ public final class OAuth2AuthorizationCodeRequestAuthenticationContext implement
 		 */
 		public Builder registeredClient(RegisteredClient registeredClient) {
 			return put(RegisteredClient.class, registeredClient);
+		}
+
+		/**
+		 * Sets the {@link OAuth2AuthorizationRequest oauth2 authorization request}.
+		 *
+		 * @param authorizationRequest the {@link OAuth2AuthorizationRequest}
+		 * @return the {@link Builder} for further configuration
+		 * @since 1.3.0
+		 */
+		public Builder authorizationRequest(OAuth2AuthorizationRequest authorizationRequest) {
+			return put(OAuth2AuthorizationRequest.class, authorizationRequest);
+		}
+
+		/**
+		 * Sets the {@link OAuth2AuthorizationConsent oauth2 authorization consent}.
+		 *
+		 * @param authorizationConsent the {@link OAuth2AuthorizationConsent}
+		 * @return the {@link Builder} for further configuration
+		 * @since 1.3.0
+		 */
+		public Builder authorizationConsent(OAuth2AuthorizationConsent authorizationConsent) {
+			return put(OAuth2AuthorizationConsent.class, authorizationConsent);
 		}
 
 		/**


### PR DESCRIPTION
This PR fixes [Issue-1541](https://github.com/spring-projects/spring-authorization-server/issues/1541#issue-2143352464)

Some things worth mentioning.

1. The Predicate naming is too similar to the private method name, do you think we should find a different name?
2. The private method is not static anymore since I am checking the predicate inside it and therefore i had to remove the static modifier and I've moved it above the other static methods in the file.
3. I've added the logic in such a way that if predicate exists it will immediately exit according to its evaluation, without going through further checks(such as if authorization consent is enabled in client settings). I figured if someone sets the predicate they want it to have full control instead of still going through additional checks which are currently in place(scopes, previous consent etc.)