### PR TITLE
Update OAuth2ClientAuthenticationFilter

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientAuthenticationToken.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientAuthenticationToken.java
@@ -129,4 +129,21 @@ public class OAuth2ClientAuthenticationToken extends AbstractAuthenticationToken
 		return this.additionalParameters;
 	}
 
+	/**
+	 * Indicates if the client secret is needed for client authentication.
+	 * Checks if the authentication method is either 'client_secret_basic' or 'client_secret_post',
+	 * both requiring the client secret for authentication.
+	 * @return {@code true} if the client secret is required, {@code false} otherwise
+	 */
+	public boolean isClientSecretRequired() {
+		return getClientAuthenticationMethod() == ClientAuthenticationMethod.CLIENT_SECRET_BASIC ||
+				getClientAuthenticationMethod() == ClientAuthenticationMethod.CLIENT_SECRET_POST;}
+
+	/**
+	 * Returns the client secret.
+	 *
+	 * @return the client secret
+	 */
+	public Object getClientSecret() {
+		return getCredentials();}
 }

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2ClientAuthenticationFilter.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2ClientAuthenticationFilter.java
@@ -119,6 +119,7 @@ public final class OAuth2ClientAuthenticationFilter extends OncePerRequestFilter
 			}
 			if (authenticationRequest != null) {
 				validateClientIdentifier(authenticationRequest);
+				validateClientAuthenticationMethod(authenticationRequest);
 				Authentication authenticationResult = this.authenticationManager.authenticate(authenticationRequest);
 				this.authenticationSuccessHandler.onAuthenticationSuccess(request, response, authenticationResult);
 			}
@@ -222,5 +223,13 @@ public final class OAuth2ClientAuthenticationFilter extends OncePerRequestFilter
 			}
 		}
 	}
+	private static void validateClientAuthenticationMethod(Authentication authentication) {
+		if (!(authentication instanceof OAuth2ClientAuthenticationToken clientAuthentication)) {
+			return;
+		}
 
+		if (clientAuthentication.isClientSecretRequired() && clientAuthentication.getClientSecret() == null) {
+			throw new OAuth2AuthenticationException(new OAuth2Error(OAuth2ErrorCodes.INVALID_REQUEST));
+		}
+	}
 }


### PR DESCRIPTION
This update enhances the OAuth2ClientAuthenticationFilter by adding the method validateClientAuthenticationMethod(Authentication authentication). This method ensures that client authentication methods requiring a client secret have it included in the authentication process. Additionally, the getClientSecret() method has been added to the OAuth2ClientAuthenticationToken class. These changes ensure compliance with the Client Authentication specifications outlined in the OAuth 2.0 RFC.