### PR TITLE
Add update-antora-ui-spring.yml workflow

### DIFF
--- a/.github/workflows/update-antora-ui-spring.yml
+++ b/.github/workflows/update-antora-ui-spring.yml
@@ -1,0 +1,22 @@
+name: Update Antora UI Spring
+
+on:
+  schedule:
+    - cron: '0 10 * * *' # Once per day at 10am UTC
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: write
+
+jobs:
+  update-antora-ui-spring-docs-build:
+    runs-on: ubuntu-latest
+    name: Update on docs-build
+    steps:
+      - uses: spring-io/spring-doc-actions/update-antora-spring-ui@17ed79ea5fbd65813c69ef1062a024d4a37ff0ca
+        name: Update
+        with:
+          docs-branch: 'docs-build'
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow will take care of updating the [`antora-ui-spring` artifact](https://github.com/spring-projects/spring-authorization-server/blob/docs-build/antora-playbook.yml#L40) from the `docs-build` branch.

See https://github.com/spring-io/spring-doc-actions?tab=readme-ov-file#update-antora-ui-spring for more details