### PR TITLE
Fix AOT hints for OAuth 2.0 Token Exchange

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/aot/hint/OAuth2AuthorizationServerBeanRegistrationAotProcessor.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/aot/hint/OAuth2AuthorizationServerBeanRegistrationAotProcessor.java
@@ -151,11 +151,11 @@ class OAuth2AuthorizationServerBeanRegistrationAotProcessor implements BeanRegis
 			this.reflectionHintsRegistrar.registerReflectionHints(hints.reflection(),
 					loadClass("org.springframework.security.jackson2.SimpleGrantedAuthorityMixin"));
 			this.reflectionHintsRegistrar.registerReflectionHints(hints.reflection(), loadClass(
-					"org.springframework.security.oauth2.server.authorization.jackson2.OAuth2ActorAuthenticationTokenMixin"));
+					"org.springframework.security.oauth2.server.authorization.jackson2.OAuth2TokenExchangeActorMixin"));
 			this.reflectionHintsRegistrar.registerReflectionHints(hints.reflection(), loadClass(
 					"org.springframework.security.oauth2.server.authorization.jackson2.OAuth2AuthorizationRequestMixin"));
 			this.reflectionHintsRegistrar.registerReflectionHints(hints.reflection(), loadClass(
-					"org.springframework.security.oauth2.server.authorization.jackson2.OAuth2CompositeAuthenticationTokenMixin"));
+					"org.springframework.security.oauth2.server.authorization.jackson2.OAuth2TokenExchangeCompositeAuthenticationTokenMixin"));
 			this.reflectionHintsRegistrar.registerReflectionHints(hints.reflection(), loadClass(
 					"org.springframework.security.oauth2.server.authorization.jackson2.OAuth2TokenFormatMixin"));
 


### PR DESCRIPTION
This is a proposed fix for issue #1629.

It just updates the classes to match the renaming performed by 2f1f45bc0152b6b8b414134cd2506ab01ece423d.