### PR TITLE
Fix json deserialization of multi-valued authorization request parameters

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/jackson2/OAuth2AuthorizationServerJackson2Module.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/jackson2/OAuth2AuthorizationServerJackson2Module.java
@@ -82,6 +82,7 @@ public class OAuth2AuthorizationServerJackson2Module extends SimpleModule {
 		context.setMixInAnnotations(SignatureAlgorithm.class, JwsAlgorithmMixin.class);
 		context.setMixInAnnotations(MacAlgorithm.class, JwsAlgorithmMixin.class);
 		context.setMixInAnnotations(OAuth2TokenFormat.class, OAuth2TokenFormatMixin.class);
+		context.setMixInAnnotations(String[].class, StringArrayMixin.class);
 	}
 
 }

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/jackson2/StringArrayMixin.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/jackson2/StringArrayMixin.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization.jackson2;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * This mixin class is used to serialize/deserialize {@link String} array.
+ *
+ * @author Nikola Jovanovic
+ * @since 1.2.6
+ * @see String
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+abstract class StringArrayMixin {
+
+	@JsonCreator
+	StringArrayMixin(String[] array) {
+	}
+
+}

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/jackson2/OAuth2AuthorizationServerJackson2ModuleTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/jackson2/OAuth2AuthorizationServerJackson2ModuleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 the original author or authors.
+ * Copyright 2020-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,9 @@ public class OAuth2AuthorizationServerJackson2ModuleTests {
 	private static final TypeReference<Set<String>> STRING_SET = new TypeReference<Set<String>>() {
 	};
 
+	private static final TypeReference<String[]> STRING_ARRAY = new TypeReference<String[]>() {
+	};
+
 	private ObjectMapper objectMapper;
 
 	@BeforeEach
@@ -71,6 +74,13 @@ public class OAuth2AuthorizationServerJackson2ModuleTests {
 		Set<String> set = new LinkedHashSet<>(Arrays.asList("one", "two"));
 		String json = this.objectMapper.writeValueAsString(set);
 		assertThat(this.objectMapper.readValue(json, STRING_SET)).isEqualTo(set);
+	}
+
+	@Test
+	public void readValueWhenStringArrayThenSuccess() throws Exception {
+		String[] array = new String[] { "one", "two" };
+		String json = this.objectMapper.writeValueAsString(array);
+		assertThat(this.objectMapper.readValue(json, STRING_ARRAY)).isEqualTo(array);
 	}
 
 }


### PR DESCRIPTION
I have tested this mixin on a sample spring authorization server app, by registering the mixin on a custom JdbcOAuth2AuthorizationService bean. 

Authorization flow now works correctly without throwing on multi valued parameters. String[] is correctly serialized & deserialized.

Closes gh-1666