### PR TITLE
Fix verification_uri in device authorization response when context path exists

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2DeviceAuthorizationEndpointFilter.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2DeviceAuthorizationEndpointFilter.java
@@ -228,6 +228,7 @@ public final class OAuth2DeviceAuthorizationEndpointFilter extends OncePerReques
 		UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder
 			.fromHttpUrl(UrlUtils.buildFullRequestUrl(request))
 			.replacePath(UrlPathHelper.defaultInstance.getContextPath(request))
+			.replaceQuery(null)
 			.pathSegment(relativeVerificationPath);
 		String verificationUri = uriComponentsBuilder.build().toUriString();
 		// @formatter:off

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2DeviceAuthorizationEndpointFilter.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2DeviceAuthorizationEndpointFilter.java
@@ -52,6 +52,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UrlPathHelper;
 
 /**
  * A {@code Filter} for the OAuth 2.0 Device Authorization endpoint, which handles the
@@ -219,10 +220,15 @@ public final class OAuth2DeviceAuthorizationEndpointFilter extends OncePerReques
 		OAuth2DeviceCode deviceCode = deviceAuthorizationRequestAuthentication.getDeviceCode();
 		OAuth2UserCode userCode = deviceAuthorizationRequestAuthentication.getUserCode();
 
+		String relativeVerificationPath = this.verificationUri.startsWith("/")
+			? this.verificationUri.substring(1)
+			: this.verificationUri;
+
 		// Generate the fully-qualified verification URI
 		UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder
 			.fromHttpUrl(UrlUtils.buildFullRequestUrl(request))
-			.replacePath(this.verificationUri);
+			.replacePath(UrlPathHelper.defaultInstance.getContextPath(request))
+			.pathSegment(relativeVerificationPath);
 		String verificationUri = uriComponentsBuilder.build().toUriString();
 		// @formatter:off
 		String verificationUriComplete = uriComponentsBuilder


### PR DESCRIPTION
This fixes

https://github.com/spring-projects/spring-authorization-server/issues/1714: Invalid verification_uri in device authorization response when context path exists

Before this change the reported verification URI was built by completely replacing the path of the incoming device authorization request. If the application is not running under the root path (/) this lead to an incorrect verification URI. After the change the verification URI is built relative to the context path of the application.

Additionally it clears the query part of the URI. The current code passes the query parameters used to do the device authorization query to the verification URI. IMHO that is not expected / intended behaviour.

According to https://datatracker.ietf.org/doc/html/rfc8628#section-3.1

"Parameters sent without a value MUST be treated as if they were omitted from the request.  The authorization server MUST ignore unrecognized request parameters.  Request and response parameters MUST NOT be included more than once."

Passing through is not "ignoring"

The pull request should be mergeable in main and 1.3.x

Did some quick tests with:
- application in Apache Tomcat with non-empty application root / context path (/foo/)
- application in Payara with empty application root / context path (/)
- sample demo-authorization-server with / and /foo context path

Seems to look ok for me

Fixes gh-1714