### PR TITLE
Use empty map for missing additional parameters

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2DeviceAuthorizationRequestAuthenticationToken.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2DeviceAuthorizationRequestAuthenticationToken.java
@@ -96,7 +96,7 @@ public class OAuth2DeviceAuthorizationRequestAuthenticationToken extends Abstrac
 		this.deviceCode = deviceCode;
 		this.userCode = userCode;
 		this.authorizationUri = null;
-		this.additionalParameters = null;
+		this.additionalParameters = Collections.emptyMap();
 		setAuthenticated(true);
 	}
 

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2DeviceVerificationAuthenticationToken.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2DeviceVerificationAuthenticationToken.java
@@ -80,7 +80,7 @@ public class OAuth2DeviceVerificationAuthenticationToken extends AbstractAuthent
 		this.principal = principal;
 		this.userCode = userCode;
 		this.clientId = clientId;
-		this.additionalParameters = null;
+		this.additionalParameters = Collections.emptyMap();
 		setAuthenticated(true);
 	}
 


### PR DESCRIPTION
This is not only more consistent with the other tokens which use an empty map, but also more in line with the documentation (at least for `OAuth2DeviceVerificationAuthenticationToken`).