### PR TITLE
Replace deprecated fromHttpUrl with fromUriString

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/config/annotation/web/configurers/AuthorizationServerContextFilter.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/config/annotation/web/configurers/AuthorizationServerContextFilter.java
@@ -117,7 +117,7 @@ final class AuthorizationServerContextFilter extends OncePerRequestFilter {
 			}
 
 			// @formatter:off
-			return UriComponentsBuilder.fromHttpUrl(UrlUtils.buildFullRequestUrl(request))
+			return UriComponentsBuilder.fromUriString(UrlUtils.buildFullRequestUrl(request))
 					.replacePath(path)
 					.replaceQuery(null)
 					.fragment(null)


### PR DESCRIPTION
Deprecated as of 6.2, in favor of UriComponentsBuilder.fromUriString(String); scheduled for removal in 7.0.

> Sorry, I rarely use github's PR. I have recreated the PR according to DCO.  Related #1879