### PR TITLE
Use javadoc-extension

### DIFF
--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -25,6 +25,7 @@ asciidoc:
   extensions:
   - '@asciidoctor/tabs'
   - '@springio/asciidoctor-extensions'
+  - '@springio/asciidoctor-extensions/javadoc-extension'
 urls:
   latest_version_segment_strategy: redirect:to
   latest_version_segment: ''

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -15,9 +15,6 @@ asciidoc:
   attributes:
     attribute-missing: 'warn'
     chomp: 'all'
-    spring-security-reference-base-url: "https://docs.spring.io/spring-security/reference"
-    spring-security-api-base-url: "https://docs.spring.io/spring-security/site/docs/current/api"
-    spring-boot-reference-base-url: "https://docs.spring.io/spring-boot/docs/current/reference/html"
     examples-dir: example$docs-src
     samples-dir: example$samples
     docs-java: '{examples-dir}/main/java'

--- a/docs/modules/ROOT/pages/core-model-components.adoc
+++ b/docs/modules/ROOT/pages/core-model-components.adoc
@@ -148,13 +148,13 @@ An `OAuth2Authorization` is a representation of an OAuth2 authorization, which h
 [TIP]
 The corresponding authorization model in Spring Security's OAuth2 Client support is {spring-security-reference-base-url}/servlet/oauth2/client/core.html#oauth2Client-authorized-client[OAuth2AuthorizedClient].
 
-After the successful completion of an authorization grant flow, an `OAuth2Authorization` is created and associates an {spring-security-api-base-url}/org/springframework/security/oauth2/core/OAuth2AccessToken.html[`OAuth2AccessToken`], an (optional) {spring-security-api-base-url}/org/springframework/security/oauth2/core/OAuth2RefreshToken.html[`OAuth2RefreshToken`], and additional state specific to the executed authorization grant type.
+After the successful completion of an authorization grant flow, an `OAuth2Authorization` is created and associates an javadoc:org.springframework.security.oauth2.core.OAuth2AccessToken[], an (optional) javadoc:org.springframework.security.oauth2.core.OAuth2RefreshToken[], and additional state specific to the executed authorization grant type.
 
-The {spring-security-api-base-url}/org/springframework/security/oauth2/core/OAuth2Token.html[`OAuth2Token`] instances associated with an `OAuth2Authorization` vary, depending on the authorization grant type.
+The javadoc:org.springframework.security.oauth2.core.OAuth2Token[] instances associated with an `OAuth2Authorization` vary, depending on the authorization grant type.
 
 For the OAuth2 https://datatracker.ietf.org/doc/html/rfc6749#section-4.1[authorization_code grant], an `OAuth2AuthorizationCode`, an `OAuth2AccessToken`, and an (optional) `OAuth2RefreshToken` are associated.
 
-For the OpenID Connect 1.0 https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth[authorization_code grant], an `OAuth2AuthorizationCode`, an {spring-security-api-base-url}/org/springframework/security/oauth2/core/oidc/OidcIdToken.html[`OidcIdToken`], an `OAuth2AccessToken`, and an (optional) `OAuth2RefreshToken` are associated.
+For the OpenID Connect 1.0 https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth[authorization_code grant], an `OAuth2AuthorizationCode`, an javadoc:org.springframework.security.oauth2.core.oidc.OidcIdToken[], an `OAuth2AccessToken`, and an (optional) `OAuth2RefreshToken` are associated.
 
 For the OAuth2 https://datatracker.ietf.org/doc/html/rfc6749#section-4.4[client_credentials grant], only an `OAuth2AccessToken` is associated.
 

--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -99,9 +99,9 @@ This is a minimal configuration for getting started quickly. To understand what 
 
 <1> A Spring Security filter chain for the xref:protocol-endpoints.adoc[Protocol Endpoints].
 <2> A Spring Security filter chain for https://docs.spring.io/spring-security/reference/servlet/authentication/index.html[authentication].
-<3> An instance of {spring-security-api-base-url}/org/springframework/security/core/userdetails/UserDetailsService.html[`UserDetailsService`] for retrieving users to authenticate.
+<3> An instance of javadoc:org.springframework.security.core.userdetails.UserDetailsService[] for retrieving users to authenticate.
 <4> An instance of xref:core-model-components.adoc#registered-client-repository[`RegisteredClientRepository`] for managing clients.
 <5> An instance of `com.nimbusds.jose.jwk.source.JWKSource` for signing access tokens.
 <6> An instance of `java.security.KeyPair` with keys generated on startup used to create the `JWKSource` above.
-<7> An instance of {spring-security-api-base-url}/org/springframework/security/oauth2/jwt/JwtDecoder.html[`JwtDecoder`] for decoding signed access tokens.
+<7> An instance of javadoc:org.springframework.security.oauth2.jwt.JwtDecoder[] for decoding signed access tokens.
 <8> An instance of xref:configuration-model#configuring-authorization-server-settings[`AuthorizationServerSettings`] to configure Spring Authorization Server.

--- a/docs/spring-authorization-server-docs.gradle
+++ b/docs/spring-authorization-server-docs.gradle
@@ -30,8 +30,15 @@ tasks.named("generateAntoraYml") {
 
 
 def generateAttributes() {
+	def springBootVersion = project.configurations.named("implementation").get()
+		.dependencies.find {it -> ("spring-boot-dependencies" == it.name) }
+		.version
+	String springSecurityVersion = libs.org.springframework.security.spring.security.bom.get().versionConstraint.displayName
 	return [
-			"spring-authorization-server-version": project.version
+			"spring-authorization-server-version": project.version,
+			"spring-security-reference-base-url": "https://docs.spring.io/spring-security/reference/${generateVersionWithoutPatch(springSecurityVersion)}".toString(),
+			"javadoc-location-org-springframework-security": "https://docs.spring.io/spring-security/site/docs/$springSecurityVersion/api".toString(),
+			"spring-boot-reference-base-url": "https://docs.spring.io/spring-boot/docs/${generateVersionWithoutPatch(springBootVersion)}/reference/html".toString()
 	]
 }
 
@@ -75,4 +82,17 @@ dependencies {
 
 tasks.named("test") {
 	useJUnitPlatform()
+}
+
+static String generateVersionWithoutPatch(String version) {
+
+	def matcher = version =~ /^(\d+.\d+).\d+(-SNAPSHOT|-M\d+)?$/
+	if(matcher) {
+
+		return matcher[0][2] == null || matcher[0][2].startsWith("-M")
+			? matcher[0][1]
+			: matcher[0][1] + matcher[0][2]
+	}
+
+	return version
 }

--- a/docs/spring-authorization-server-docs.gradle
+++ b/docs/spring-authorization-server-docs.gradle
@@ -35,10 +35,10 @@ def generateAttributes() {
 		.version
 	String springSecurityVersion = libs.org.springframework.security.spring.security.bom.get().versionConstraint.displayName
 	return [
-			"spring-authorization-server-version": project.version,
-			"spring-security-reference-base-url": "https://docs.spring.io/spring-security/reference/${generateVersionWithoutPatch(springSecurityVersion)}".toString(),
-			"javadoc-location-org-springframework-security": "https://docs.spring.io/spring-security/site/docs/$springSecurityVersion/api".toString(),
-			"spring-boot-reference-base-url": "https://docs.spring.io/spring-boot/docs/${generateVersionWithoutPatch(springBootVersion)}/reference/html".toString()
+			'spring-authorization-server-version': project.version,
+			'spring-security-reference-base-url': "https://docs.spring.io/spring-security/reference/${generateVersionWithoutPatch(springSecurityVersion)}".toString(),
+			'javadoc-location-org-springframework-security': "https://docs.spring.io/spring-security/site/docs/$springSecurityVersion/api".toString(),
+			'spring-boot-reference-base-url': "https://docs.spring.io/spring-boot/docs/${generateVersionWithoutPatch(springBootVersion)}/reference/html".toString()
 	]
 }
 

--- a/docs/spring-authorization-server-docs.gradle
+++ b/docs/spring-authorization-server-docs.gradle
@@ -86,13 +86,5 @@ tasks.named("test") {
 
 static String generateVersionWithoutPatch(String version) {
 
-	def matcher = version =~ /^(\d+.\d+).\d+(-SNAPSHOT|-M\d+)?$/
-	if(matcher) {
-
-		return matcher[0][2] == null || matcher[0][2].startsWith("-M")
-			? matcher[0][1]
-			: matcher[0][1] + matcher[0][2]
-	}
-
-	return version
+	return version.split('\\.')[0, 1].join('.') + (version.endsWith('-SNAPSHOT') ? '-SNAPSHOT' : '')
 }


### PR DESCRIPTION
The main points:

- The new Spring Authorization Server version document will be compatitable with Spring Framework version document
- Reference javadoc will be easier, use `javadoc:org.springframework.security...` instead `{spring-security-api-base-url}...`