### PR TITLE
Disable device_code grant by default

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/config/annotation/web/configurers/OAuth2AuthorizationServerConfigurer.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/config/annotation/web/configurers/OAuth2AuthorizationServerConfigurer.java
@@ -365,7 +365,10 @@ public final class OAuth2AuthorizationServerConfigurer
 		List<RequestMatcher> requestMatchers = new ArrayList<>();
 		this.configurers.values().forEach((configurer) -> {
 			configurer.init(httpSecurity);
-			requestMatchers.add(configurer.getRequestMatcher());
+			RequestMatcher matcher = configurer.getRequestMatcher();
+			if (matcher != null) {
+				requestMatchers.add(matcher);
+			}
 		});
 		String jwkSetEndpointUri = authorizationServerSettings.isMultipleIssuersAllowed()
 				? OAuth2ConfigurerUtils.withMultipleIssuersPattern(authorizationServerSettings.getJwkSetEndpoint())
@@ -380,7 +383,10 @@ public final class OAuth2AuthorizationServerConfigurer
 			preferredMatchers.add(getRequestMatcher(OAuth2TokenEndpointConfigurer.class));
 			preferredMatchers.add(getRequestMatcher(OAuth2TokenIntrospectionEndpointConfigurer.class));
 			preferredMatchers.add(getRequestMatcher(OAuth2TokenRevocationEndpointConfigurer.class));
-			preferredMatchers.add(getRequestMatcher(OAuth2DeviceAuthorizationEndpointConfigurer.class));
+			RequestMatcher deviceAuthMatcher = getRequestMatcher(OAuth2DeviceAuthorizationEndpointConfigurer.class);
+			if (deviceAuthMatcher != null) {
+				preferredMatchers.add(deviceAuthMatcher);
+			}
 			RequestMatcher preferredMatcher = getRequestMatcher(
 					OAuth2PushedAuthorizationRequestEndpointConfigurer.class);
 			if (preferredMatcher != null) {

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/config/annotation/web/configurers/OAuth2ClientAuthenticationConfigurer.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/config/annotation/web/configurers/OAuth2ClientAuthenticationConfigurer.java
@@ -192,19 +192,23 @@ public final class OAuth2ClientAuthenticationConfigurer extends AbstractOAuth2Co
 				? OAuth2ConfigurerUtils
 					.withMultipleIssuersPattern(authorizationServerSettings.getTokenRevocationEndpoint())
 				: authorizationServerSettings.getTokenRevocationEndpoint();
-		String deviceAuthorizationEndpointUri = authorizationServerSettings.isMultipleIssuersAllowed()
-				? OAuth2ConfigurerUtils
-					.withMultipleIssuersPattern(authorizationServerSettings.getDeviceAuthorizationEndpoint())
-				: authorizationServerSettings.getDeviceAuthorizationEndpoint();
 		String pushedAuthorizationRequestEndpointUri = authorizationServerSettings.isMultipleIssuersAllowed()
 				? OAuth2ConfigurerUtils
-					.withMultipleIssuersPattern(authorizationServerSettings.getPushedAuthorizationRequestEndpoint())
+				.withMultipleIssuersPattern(authorizationServerSettings.getPushedAuthorizationRequestEndpoint())
 				: authorizationServerSettings.getPushedAuthorizationRequestEndpoint();
-		this.requestMatcher = new OrRequestMatcher(new AntPathRequestMatcher(tokenEndpointUri, HttpMethod.POST.name()),
-				new AntPathRequestMatcher(tokenIntrospectionEndpointUri, HttpMethod.POST.name()),
-				new AntPathRequestMatcher(tokenRevocationEndpointUri, HttpMethod.POST.name()),
-				new AntPathRequestMatcher(deviceAuthorizationEndpointUri, HttpMethod.POST.name()),
-				new AntPathRequestMatcher(pushedAuthorizationRequestEndpointUri, HttpMethod.POST.name()));
+		List<RequestMatcher> requestMatchers = new ArrayList<>();
+		requestMatchers.add(new AntPathRequestMatcher(tokenEndpointUri, HttpMethod.POST.name()));
+		requestMatchers.add(new AntPathRequestMatcher(tokenIntrospectionEndpointUri, HttpMethod.POST.name()));
+		requestMatchers.add(new AntPathRequestMatcher(tokenRevocationEndpointUri, HttpMethod.POST.name()));
+		if (authorizationServerSettings.isDeviceGrantEnabled()) {
+			String deviceAuthorizationEndpointUri = authorizationServerSettings.isMultipleIssuersAllowed()
+					? OAuth2ConfigurerUtils
+					.withMultipleIssuersPattern(authorizationServerSettings.getDeviceAuthorizationEndpoint())
+					: authorizationServerSettings.getDeviceAuthorizationEndpoint();
+			requestMatchers.add(new AntPathRequestMatcher(deviceAuthorizationEndpointUri, HttpMethod.POST.name()));
+		}
+		requestMatchers.add(new AntPathRequestMatcher(pushedAuthorizationRequestEndpointUri, HttpMethod.POST.name()));
+		this.requestMatcher = new OrRequestMatcher(requestMatchers);
 		List<AuthenticationProvider> authenticationProviders = createDefaultAuthenticationProviders(httpSecurity);
 		if (!this.authenticationProviders.isEmpty()) {
 			authenticationProviders.addAll(0, this.authenticationProviders);

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/config/annotation/web/configurers/OAuth2DeviceAuthorizationEndpointConfigurer.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/config/annotation/web/configurers/OAuth2DeviceAuthorizationEndpointConfigurer.java
@@ -197,10 +197,13 @@ public final class OAuth2DeviceAuthorizationEndpointConfigurer extends AbstractO
 	@Override
 	public void init(HttpSecurity builder) {
 		AuthorizationServerSettings authorizationServerSettings = OAuth2ConfigurerUtils
-			.getAuthorizationServerSettings(builder);
+				.getAuthorizationServerSettings(builder);
+		if (!authorizationServerSettings.isDeviceGrantEnabled()) {
+			return;
+		}
 		String deviceAuthorizationEndpointUri = authorizationServerSettings.isMultipleIssuersAllowed()
 				? OAuth2ConfigurerUtils
-					.withMultipleIssuersPattern(authorizationServerSettings.getDeviceAuthorizationEndpoint())
+				.withMultipleIssuersPattern(authorizationServerSettings.getDeviceAuthorizationEndpoint())
 				: authorizationServerSettings.getDeviceAuthorizationEndpoint();
 		this.requestMatcher = new AntPathRequestMatcher(deviceAuthorizationEndpointUri, HttpMethod.POST.name());
 
@@ -217,7 +220,11 @@ public final class OAuth2DeviceAuthorizationEndpointConfigurer extends AbstractO
 	public void configure(HttpSecurity builder) {
 		AuthenticationManager authenticationManager = builder.getSharedObject(AuthenticationManager.class);
 		AuthorizationServerSettings authorizationServerSettings = OAuth2ConfigurerUtils
-			.getAuthorizationServerSettings(builder);
+				.getAuthorizationServerSettings(builder);
+
+		if (!authorizationServerSettings.isDeviceGrantEnabled()) {
+			return;
+		}
 
 		String deviceAuthorizationEndpointUri = authorizationServerSettings.isMultipleIssuersAllowed()
 				? OAuth2ConfigurerUtils

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/config/annotation/web/configurers/OAuth2DeviceVerificationEndpointConfigurer.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/config/annotation/web/configurers/OAuth2DeviceVerificationEndpointConfigurer.java
@@ -232,10 +232,13 @@ public final class OAuth2DeviceVerificationEndpointConfigurer extends AbstractOA
 	@Override
 	public void init(HttpSecurity builder) {
 		AuthorizationServerSettings authorizationServerSettings = OAuth2ConfigurerUtils
-			.getAuthorizationServerSettings(builder);
+				.getAuthorizationServerSettings(builder);
+		if (!authorizationServerSettings.isDeviceGrantEnabled()) {
+			return;
+		}
 		String deviceVerificationEndpointUri = authorizationServerSettings.isMultipleIssuersAllowed()
 				? OAuth2ConfigurerUtils
-					.withMultipleIssuersPattern(authorizationServerSettings.getDeviceVerificationEndpoint())
+				.withMultipleIssuersPattern(authorizationServerSettings.getDeviceVerificationEndpoint())
 				: authorizationServerSettings.getDeviceVerificationEndpoint();
 		this.requestMatcher = new OrRequestMatcher(
 				new AntPathRequestMatcher(deviceVerificationEndpointUri, HttpMethod.GET.name()),
@@ -254,7 +257,11 @@ public final class OAuth2DeviceVerificationEndpointConfigurer extends AbstractOA
 	public void configure(HttpSecurity builder) {
 		AuthenticationManager authenticationManager = builder.getSharedObject(AuthenticationManager.class);
 		AuthorizationServerSettings authorizationServerSettings = OAuth2ConfigurerUtils
-			.getAuthorizationServerSettings(builder);
+				.getAuthorizationServerSettings(builder);
+
+		if (!authorizationServerSettings.isDeviceGrantEnabled()) {
+			return;
+		}
 
 		String deviceVerificationEndpointUri = authorizationServerSettings.isMultipleIssuersAllowed()
 				? OAuth2ConfigurerUtils

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/settings/AuthorizationServerSettings.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/settings/AuthorizationServerSettings.java
@@ -164,20 +164,30 @@ public final class AuthorizationServerSettings extends AbstractSettings {
 	}
 
 	/**
+	 * Returns {@code true} if the OAuth 2.0 Device Authorization Grant is enabled.
+	 * The default is {@code false}.
+	 * @return {@code true} if the Device Authorization Grant is enabled, {@code false} otherwise
+	 */
+	public boolean isDeviceGrantEnabled() {
+		return getSetting(ConfigurationSettingNames.AuthorizationServer.DEVICE_GRANT_ENABLED);
+	}
+
+	/**
 	 * Constructs a new {@link Builder} with the default settings.
 	 * @return the {@link Builder}
 	 */
 	public static Builder builder() {
 		return new Builder().multipleIssuersAllowed(false)
-			.authorizationEndpoint("/oauth2/authorize")
-			.pushedAuthorizationRequestEndpoint("/oauth2/par")
-			.deviceAuthorizationEndpoint("/oauth2/device_authorization")
-			.deviceVerificationEndpoint("/oauth2/device_verification")
-			.tokenEndpoint("/oauth2/token")
-			.jwkSetEndpoint("/oauth2/jwks")
-			.tokenRevocationEndpoint("/oauth2/revoke")
-			.tokenIntrospectionEndpoint("/oauth2/introspect")
-			.oidcClientRegistrationEndpoint("/connect/register")
+				.authorizationEndpoint("/oauth2/authorize")
+				.pushedAuthorizationRequestEndpoint("/oauth2/par")
+				.deviceAuthorizationEndpoint("/oauth2/device_authorization")
+				.deviceVerificationEndpoint("/oauth2/device_verification")
+				.deviceGrantEnabled(false)
+				.tokenEndpoint("/oauth2/token")
+				.jwkSetEndpoint("/oauth2/jwks")
+				.tokenRevocationEndpoint("/oauth2/revoke")
+				.tokenIntrospectionEndpoint("/oauth2/introspect")
+				.oidcClientRegistrationEndpoint("/connect/register")
 			.oidcUserInfoEndpoint("/userinfo")
 			.oidcLogoutEndpoint("/connect/logout");
 	}
@@ -279,6 +289,16 @@ public final class AuthorizationServerSettings extends AbstractSettings {
 		public Builder deviceVerificationEndpoint(String deviceVerificationEndpoint) {
 			return setting(ConfigurationSettingNames.AuthorizationServer.DEVICE_VERIFICATION_ENDPOINT,
 					deviceVerificationEndpoint);
+		}
+
+		/**
+		 * Enables the OAuth 2.0 Device Authorization Grant.
+		 * @param deviceGrantEnabled {@code true} to enable the Device Authorization Grant
+		 * @return the {@link Builder} for further configuration
+		 */
+		public Builder deviceGrantEnabled(boolean deviceGrantEnabled) {
+			return setting(ConfigurationSettingNames.AuthorizationServer.DEVICE_GRANT_ENABLED,
+					deviceGrantEnabled);
 		}
 
 		/**

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/settings/ConfigurationSettingNames.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/settings/ConfigurationSettingNames.java
@@ -129,7 +129,15 @@ public final class ConfigurationSettingNames {
 		 * Set the OAuth 2.0 Device Verification endpoint.
 		 */
 		public static final String DEVICE_VERIFICATION_ENDPOINT = AUTHORIZATION_SERVER_SETTINGS_NAMESPACE
-			.concat("device-verification-endpoint");
+				.concat("device-verification-endpoint");
+
+		/**
+		 * Set to {@code true} if the OAuth 2.0 Device Authorization Grant is enabled.
+		 * The default is {@code false}.
+		 */
+		public static final String DEVICE_GRANT_ENABLED = AUTHORIZATION_SERVER_SETTINGS_NAMESPACE
+				.concat("device-grant-enabled");
+
 
 		/**
 		 * Set the OAuth 2.0 Token endpoint.

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/config/annotation/web/configurers/OAuth2DeviceCodeGrantTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/config/annotation/web/configurers/OAuth2DeviceCodeGrantTests.java
@@ -176,8 +176,16 @@ public class OAuth2DeviceCodeGrantTests {
 	}
 
 	@Test
-	public void requestWhenDeviceAuthorizationRequestNotAuthenticatedThenUnauthorized() throws Exception {
+	public void requestWhenDeviceAuthorizationEndpointDisabledThenNotFound() throws Exception {
 		this.spring.register(AuthorizationServerConfiguration.class).autowire();
+
+		this.mvc.perform(post(DEFAULT_DEVICE_AUTHORIZATION_ENDPOINT_URI))
+				.andExpect(status().isNotFound());
+	}
+
+	@Test
+	public void requestWhenDeviceAuthorizationRequestNotAuthenticatedThenUnauthorized() throws Exception {
+		this.spring.register(AuthorizationServerConfigurationWithDeviceGrant.class).autowire();
 
 		// @formatter:off
 		RegisteredClient registeredClient = TestRegisteredClients.registeredClient()
@@ -200,7 +208,7 @@ public class OAuth2DeviceCodeGrantTests {
 
 	@Test
 	public void requestWhenRegisteredClientMissingThenUnauthorized() throws Exception {
-		this.spring.register(AuthorizationServerConfiguration.class).autowire();
+		this.spring.register(AuthorizationServerConfigurationWithDeviceGrant.class).autowire();
 
 		// @formatter:off
 		RegisteredClient registeredClient = TestRegisteredClients.registeredClient()
@@ -272,7 +280,7 @@ public class OAuth2DeviceCodeGrantTests {
 
 	@Test
 	public void requestWhenDeviceVerificationRequestUnauthenticatedThenUnauthorized() throws Exception {
-		this.spring.register(AuthorizationServerConfiguration.class).autowire();
+		this.spring.register(AuthorizationServerConfigurationWithDeviceGrant.class).autowire();
 
 		// @formatter:off
 		RegisteredClient registeredClient = TestRegisteredClients.registeredClient()
@@ -357,7 +365,7 @@ public class OAuth2DeviceCodeGrantTests {
 
 	@Test
 	public void requestWhenDeviceAuthorizationConsentRequestUnauthenticatedThenBadRequest() throws Exception {
-		this.spring.register(AuthorizationServerConfiguration.class).autowire();
+		this.spring.register(AuthorizationServerConfigurationWithDeviceGrant.class).autowire();
 
 		// @formatter:off
 		RegisteredClient registeredClient = TestRegisteredClients.registeredClient()
@@ -395,7 +403,7 @@ public class OAuth2DeviceCodeGrantTests {
 
 	@Test
 	public void requestWhenDeviceAuthorizationConsentRequestValidThenRedirectsToSuccessPage() throws Exception {
-		this.spring.register(AuthorizationServerConfiguration.class).autowire();
+		this.spring.register(AuthorizationServerConfigurationWithDeviceGrant.class).autowire();
 
 		// @formatter:off
 		RegisteredClient registeredClient = TestRegisteredClients.registeredClient()
@@ -445,7 +453,7 @@ public class OAuth2DeviceCodeGrantTests {
 
 	@Test
 	public void requestWhenAccessTokenRequestUnauthenticatedThenUnauthorized() throws Exception {
-		this.spring.register(AuthorizationServerConfiguration.class).autowire();
+		this.spring.register(AuthorizationServerConfigurationWithDeviceGrant.class).autowire();
 
 		// @formatter:off
 		RegisteredClient registeredClient = TestRegisteredClients.registeredClient()
@@ -481,7 +489,7 @@ public class OAuth2DeviceCodeGrantTests {
 
 	@Test
 	public void requestWhenAccessTokenRequestValidThenReturnAccessTokenResponse() throws Exception {
-		this.spring.register(AuthorizationServerConfiguration.class).autowire();
+		this.spring.register(AuthorizationServerConfigurationWithDeviceGrant.class).autowire();
 
 		// @formatter:off
 		RegisteredClient registeredClient = TestRegisteredClients.registeredClient()
@@ -553,7 +561,7 @@ public class OAuth2DeviceCodeGrantTests {
 
 	@Test
 	public void requestWhenAccessTokenRequestWithDPoPProofThenReturnDPoPBoundAccessToken() throws Exception {
-		this.spring.register(AuthorizationServerConfiguration.class).autowire();
+		this.spring.register(AuthorizationServerConfigurationWithDeviceGrant.class).autowire();
 
 		// @formatter:off
 		RegisteredClient registeredClient = TestRegisteredClients.registeredClient()
@@ -683,11 +691,24 @@ public class OAuth2DeviceCodeGrantTests {
 
 	@EnableWebSecurity
 	@Import(OAuth2AuthorizationServerConfiguration.class)
-	static class AuthorizationServerConfigurationWithMultipleIssuersAllowed extends AuthorizationServerConfiguration {
+	static class AuthorizationServerConfigurationWithDeviceGrant extends AuthorizationServerConfiguration {
 
 		@Bean
 		AuthorizationServerSettings authorizationServerSettings() {
-			return AuthorizationServerSettings.builder().multipleIssuersAllowed(true).build();
+			return AuthorizationServerSettings.builder().deviceGrantEnabled(true).build();
+		}
+
+	}
+
+	@EnableWebSecurity
+	@Import(OAuth2AuthorizationServerConfiguration.class)
+	static class AuthorizationServerConfigurationWithMultipleIssuersAllowed extends AuthorizationServerConfigurationWithDeviceGrant {
+
+		@Bean
+		AuthorizationServerSettings authorizationServerSettings() {
+			return AuthorizationServerSettings.builder().multipleIssuersAllowed(true)
+					.deviceGrantEnabled(true)
+					.build();
 		}
 
 	}


### PR DESCRIPTION
## Overview

This PR introduces an opt-in switch for the OAuth 2.0 **Device Authorization Grant** (aka `device_code`) in Spring Authorization Server.
By default the grant is **disabled**, bringing the framework in line with the “secure-by-default” principle discussed in [[#1709](https://github.com/spring-projects/spring-security/issues/17998)](https://github.com/spring-projects/spring-security/issues/17998).

---

## Motivation

* The Device Authorization Grant is purpose-built for devices that have limited input capabilities.
  Most new deployments of the Authorization Server target browser-based or mobile clients and do **not** require this flow.
* Exposing unused endpoints (`/oauth2/device_authorization`, `/oauth2/device_verification`) increases the attack surface and the number of code paths that must be audited.
* Disabling the grant unless explicitly requested mirrors the framework’s stance on other advanced or niche features (e.g. PAR being optional).

---

## What changed

| Area                              | Change                                                                                                                                                                                                                    |
| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **`AuthorizationServerSettings`** | *New flag* `deviceGrantEnabled` (default `false`).                                                                                                                                                                        |
|                                   | Builder API: `deviceGrantEnabled(boolean)` – fluent opt-in.                                                                                                                                                               |
| **Endpoint configurers**          | `OAuth2DeviceAuthorizationEndpointConfigurer` and `OAuth2DeviceVerificationEndpointConfigurer` now short-circuit their `init()` / `configure()` methods when the flag is `false`. No filters or providers are registered. |
| **Global configurer**             | `OAuth2AuthorizationServerConfigurer` skips Device Grant matchers unless the flag is enabled; avoids null request-matcher issues.                                                                                         |
| **Settings names**                | Added `device-grant-enabled` to `ConfigurationSettingNames.AuthorizationServer`.                                                                                                                                          |
| **Tests**                         | Updated existing Device Grant integration tests to enable the flag explicitly. Added a new test asserting that the endpoints return `404` when the flag is left at its default value.                                     |
| **Docs / headers**                | All new code carries the Apache 2.0 header. Javadoc updated where relevant.                                                                                                                                               |

---

## Opting back in

```java
@Bean
AuthorizationServerSettings authorizationServerSettings() {
    return AuthorizationServerSettings.builder()
            .deviceGrantEnabled(true)   // <-- enable Device Grant
            // other custom settings …
            .build();
}
```

Once enabled, behaviour is identical to previous versions; no further changes are required in client or resource owner flows.

---

## Backward compatibility

* **Breaking change?**
  No—deployments that actively use the Device Grant just need to flip one property. All other grants continue to function unchanged.
* **Binary compatibility**: Existing API signatures are untouched; only one boolean accessor/mutator is added.
* **Semantic compatibility**: If `deviceGrantEnabled(true)` is configured the runtime behaviour is byte-for-byte equivalent to current `main`.

---

## Test coverage

* **Happy path tests**: All existing `OAuth2DeviceCodeGrantTests` now run with the flag enabled.
* **Negative path test**: New test `requestWhenDeviceAuthorizationEndpointDisabledThenNotFound` verifies that the endpoint is not exposed by default.
* **CI**: All modules compile and the full test suite passes (`./gradlew check`).

---

## Upgrade notes

1. If your application relies on the Device Authorization Grant, add
   `deviceGrantEnabled(true)` to your `AuthorizationServerSettings` bean (see snippet above).
2. No migration is required for applications that do not use the grant; they are now more secure by default.

---

## Related links

* Fixes spring-projects/spring-security#17998
* OWASP “Secure by Default” principle: [https://owasp.org/www-project-top-ten/](https://owasp.org/www-project-top-ten/)

---

### Checklist

* [x] Code compiles (`./gradlew clean build`)
* [x] All tests pass
* [x] New functionality documented via Javadoc
* [x] Commit signed (`Signed-off-by`) and follows Conventional Commit format

---

*Signed-off-by: **renechoi** [[renechoi90@gmail.com]