### PR TITLE
Make PAR request URI lifetime configurable

### DIFF
--- a/docs/modules/ROOT/pages/protocol-endpoints.adoc
+++ b/docs/modules/ROOT/pages/protocol-endpoints.adoc
@@ -153,6 +153,7 @@ public SecurityFilterChain authorizationServerSecurityFilterChain(HttpSecurity h
                         .authenticationProviders(authenticationProvidersConsumer)   <4>
                         .pushedAuthorizationResponseHandler(pushedAuthorizationResponseHandler) <5>
                         .errorResponseHandler(errorResponseHandler) <6>
+                        .requestUriTtl(requestUriTtl) <7>
 				)
 		);
 
@@ -165,6 +166,7 @@ public SecurityFilterChain authorizationServerSecurityFilterChain(HttpSecurity h
 <4> `authenticationProviders()`: Sets the `Consumer` providing access to the `List` of default and (optionally) added ``AuthenticationProvider``'s allowing the ability to add, remove, or customize a specific `AuthenticationProvider`.
 <5> `pushedAuthorizationResponseHandler()`: The `AuthenticationSuccessHandler` (_post-processor_) used for handling an "`authenticated`" `OAuth2PushedAuthorizationRequestAuthenticationToken` and returning the https://datatracker.ietf.org/doc/html/rfc9126#section-2.2[OAuth2 pushed authorization response].
 <6> `errorResponseHandler()`: The `AuthenticationFailureHandler` (_post-processor_) used for handling an `OAuth2AuthenticationException` and returning the https://datatracker.ietf.org/doc/html/rfc9126#section-2.3[OAuth2Error response].
+<7> `requestUriTtl()`: The lifespan, as a positive `Duration`, of the https://datatracker.ietf.org/doc/html/rfc9126#section-2.1[OAuth2 pushed authorization request]. Used to calculate the `expires_in` response parameter of the https://datatracker.ietf.org/doc/html/rfc9126#section-2.2[OAuth2 pushed authorization response].
 
 `OAuth2PushedAuthorizationRequestEndpointConfigurer` configures the `OAuth2PushedAuthorizationRequestEndpointFilter` and registers it with the OAuth2 authorization server `SecurityFilterChain` `@Bean`.
 `OAuth2PushedAuthorizationRequestEndpointFilter` is the `Filter` that processes OAuth2 pushed authorization requests.

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2PushedAuthorizationRequestUri.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2PushedAuthorizationRequestUri.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.security.oauth2.server.authorization.authentication;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
 
@@ -43,8 +44,8 @@ final class OAuth2PushedAuthorizationRequestUri {
 
 	private Instant expiresAt;
 
-	static OAuth2PushedAuthorizationRequestUri create() {
-		return create(Instant.now().plusSeconds(300));
+	static OAuth2PushedAuthorizationRequestUri create(Duration ttl) {
+		return create(Instant.now().plus(ttl));
 	}
 
 	static OAuth2PushedAuthorizationRequestUri create(Instant expiresAt) {

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeRequestAuthenticationProviderTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeRequestAuthenticationProviderTests.java
@@ -16,6 +16,7 @@
 package org.springframework.security.oauth2.server.authorization.authentication;
 
 import java.security.Principal;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
@@ -615,7 +616,7 @@ public class OAuth2AuthorizationCodeRequestAuthenticationProviderTests {
 			.willReturn(registeredClient);
 
 		OAuth2PushedAuthorizationRequestUri pushedAuthorizationRequestUri = OAuth2PushedAuthorizationRequestUri
-			.create();
+			.create(Duration.ofMinutes(5));
 		Map<String, Object> additionalParameters = new HashMap<>();
 		additionalParameters.put(OAuth2ParameterNames.REQUEST_URI, pushedAuthorizationRequestUri.getRequestUri());
 		OAuth2Authorization authorization = TestOAuth2Authorizations
@@ -641,7 +642,7 @@ public class OAuth2AuthorizationCodeRequestAuthenticationProviderTests {
 		RegisteredClient registeredClient = TestRegisteredClients.registeredClient().build();
 
 		OAuth2PushedAuthorizationRequestUri pushedAuthorizationRequestUri = OAuth2PushedAuthorizationRequestUri
-			.create();
+			.create(Duration.ofMinutes(5));
 		Map<String, Object> additionalParameters = new HashMap<>();
 		additionalParameters.put(OAuth2ParameterNames.REQUEST_URI, pushedAuthorizationRequestUri.getRequestUri());
 		OAuth2Authorization authorization = TestOAuth2Authorizations
@@ -666,7 +667,7 @@ public class OAuth2AuthorizationCodeRequestAuthenticationProviderTests {
 		RegisteredClient anotherRegisteredClient = TestRegisteredClients.registeredClient2().build();
 
 		OAuth2PushedAuthorizationRequestUri pushedAuthorizationRequestUri = OAuth2PushedAuthorizationRequestUri
-			.create();
+			.create(Duration.ofMinutes(5));
 		Map<String, Object> additionalParameters = new HashMap<>();
 		additionalParameters.put(OAuth2ParameterNames.REQUEST_URI, pushedAuthorizationRequestUri.getRequestUri());
 		OAuth2Authorization authorization = TestOAuth2Authorizations

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2PushedAuthorizationRequestAuthenticationProviderTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2PushedAuthorizationRequestAuthenticationProviderTests.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.security.oauth2.server.authorization.authentication;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -23,6 +24,8 @@ import java.util.function.Consumer;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
@@ -67,14 +70,33 @@ public class OAuth2PushedAuthorizationRequestAuthenticationProviderTests {
 	public void setUp() {
 		this.authorizationService = mock(OAuth2AuthorizationService.class);
 		this.authenticationProvider = new OAuth2PushedAuthorizationRequestAuthenticationProvider(
-				this.authorizationService);
+				this.authorizationService, Duration.ofSeconds(30L));
 	}
 
 	@Test
 	public void constructorWhenAuthorizationServiceNullThenThrowIllegalArgumentException() {
-		assertThatThrownBy(() -> new OAuth2PushedAuthorizationRequestAuthenticationProvider(null))
+		assertThatThrownBy(() -> new OAuth2PushedAuthorizationRequestAuthenticationProvider(null, null))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("authorizationService cannot be null");
+	}
+
+	@Test
+	public void constructorWhenDurationNullThenThrowIllegalArgumentException() {
+		this.authorizationService = mock(OAuth2AuthorizationService.class);
+		assertThatThrownBy(
+				() -> new OAuth2PushedAuthorizationRequestAuthenticationProvider(this.authorizationService, null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("requestUriTtl cannot be null");
+	}
+
+	@ParameterizedTest
+	@ValueSource(longs = { 0, -1 })
+	public void constructorWhenDurationZeroOrNegativeThenThrowIllegalArgumentException(final long millis) {
+		this.authorizationService = mock(OAuth2AuthorizationService.class);
+		assertThatThrownBy(() -> new OAuth2PushedAuthorizationRequestAuthenticationProvider(this.authorizationService,
+				Duration.ofMillis(millis)))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("requestUriTtl cannot be zero or negative");
 	}
 
 	@Test


### PR DESCRIPTION
- Replaces the hard-coded lifespan in `OAuth2PushedAuthorizationRequestUri` with a parameter.
- Adds a time-to-live attribute to `OAuth2PushedAuthorizationRequestAuthenticationProvider` to be passed to `OAuth2PushedAuthorizationRequestUri`.
- Defines a matching parameter in `OAuth2PushedAuthorizationRequestEndpointConfigurer`, with a default value of 5 minutes (same as the previous hard-coded value).
- Provides documentation for this new parameter.

The time-to-live must be a strictly positive duration.

The previous default behaviour is retained, no change is required to existing code.

Fixes gh-2042