### PR TITLE
Make OAuth2AuthorizationCodeGrantTests deterministic

### DIFF
--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/TestOAuth2Authorizations.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/TestOAuth2Authorizations.java
@@ -18,9 +18,13 @@ package org.springframework.security.oauth2.server.authorization;
 import java.security.Principal;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
@@ -76,11 +80,17 @@ public final class TestOAuth2Authorizations {
 	private static OAuth2Authorization.Builder authorization(RegisteredClient registeredClient,
 			OAuth2AuthorizationCode authorizationCode, OAuth2AccessToken accessToken,
 			Map<String, Object> accessTokenClaims, Map<String, Object> authorizationRequestAdditionalParameters) {
+
+		List<String> sortedRedirectUris = new ArrayList<>(registeredClient.getRedirectUris());
+    	Collections.sort(sortedRedirectUris);
+
+    	Set<String> sortedScopes = new TreeSet<>(registeredClient.getScopes());
+
 		OAuth2AuthorizationRequest authorizationRequest = OAuth2AuthorizationRequest.authorizationCode()
 			.authorizationUri("https://provider.com/oauth2/authorize")
 			.clientId(registeredClient.getClientId())
-			.redirectUri(registeredClient.getRedirectUris().iterator().next())
-			.scopes(registeredClient.getScopes())
+			.redirectUri(sortedRedirectUris.get(0))
+			.scopes(sortedScopes)
 			.additionalParameters(authorizationRequestAdditionalParameters)
 			.state("state")
 			.build();

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/config/annotation/web/configurers/OAuth2AuthorizationCodeGrantTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/config/annotation/web/configurers/OAuth2AuthorizationCodeGrantTests.java
@@ -23,8 +23,10 @@ import java.security.Principal;
 import java.text.MessageFormat;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -1113,7 +1115,9 @@ public class OAuth2AuthorizationCodeGrantTests {
 		parameters.set(OAuth2ParameterNames.GRANT_TYPE, AuthorizationGrantType.AUTHORIZATION_CODE.getValue());
 		parameters.set(OAuth2ParameterNames.CODE,
 				authorization.getToken(OAuth2AuthorizationCode.class).getToken().getTokenValue());
-		parameters.set(OAuth2ParameterNames.REDIRECT_URI, registeredClient.getRedirectUris().iterator().next());
+		List<String> sortedRedirectUris = new ArrayList<>(registeredClient.getRedirectUris());
+		Collections.sort(sortedRedirectUris);
+		parameters.set(OAuth2ParameterNames.REDIRECT_URI, sortedRedirectUris.get(0));
 		return parameters;
 	}
 


### PR DESCRIPTION
The `requestWhenConsentRequestThenReturnAccessTokenResponse` test is found to be non-deterministic because it relies on the iteration order of unordered Set in the test setup. 

This commit resolves the issue by ensuring a stable order by modifying 2 files:

1.  The selection of a `redirect_uri` from the `RegisteredClient` is now deterministic by sorting the collection before selecting an element.

2.  The creation of the `OAuth2Authorization` test data in `TestOAuth2Authorizations` was updated to handle unordered collections.