### PR TITLE
Improve migration guidance

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,10 @@
 = Spring Authorization Server image:https://badges.gitter.im/Join%20Chat.svg[Gitter,link=https://gitter.im/spring-projects/spring-security?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge] image:https://github.com/spring-projects/spring-authorization-server/actions/workflows/continuous-integration-workflow.yml/badge.svg["Build Status", link="https://github.com/spring-projects/spring-authorization-server/actions/workflows/continuous-integration-workflow.yml"] image:https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A["Revved up by Develocity", link="https://ge.spring.io/scans?&search.rootProjectNames=spring-authorization-server"]
 
-== NOTICE:
-
+[IMPORTANT]
+====
 Spring Authorization Server has https://spring.io/blog/2025/09/11/spring-authorization-server-moving-to-spring-security-7-0[moved to Spring Security 7.0].
+All ongoing development now happens in Spring Security: https://github.com/spring-projects/spring-security/tree/main/oauth2[github.com/spring-projects/spring-security/tree/main/oauth2].
+====
 
 The *1.5.x* branch is the last generation of Spring Authorization Server. See the OSS and Enterprise https://spring.io/projects/spring-authorization-server#support[support timelines].
 

--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -2,6 +2,13 @@
 [[getting-started]]
 = Getting Started
 
+[IMPORTANT]
+====
+Spring Authorization Server has https://spring.io/blog/2025/09/11/spring-authorization-server-moving-to-spring-security-7-0[moved to Spring Security 7.0] and this documentation is no longer updated for Spring Boot 4.
+If you are on Spring Boot 4 (or migrating), use the Spring Security Authorization Server documentation:
+https://docs.spring.io/spring-security/reference/servlet/oauth2/authorization-server/index.html[Spring Security Authorization Server Reference].
+====
+
 If you are just getting started with Spring Authorization Server, the following sections walk you through creating your first application.
 
 [[system-requirements]]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -2,6 +2,13 @@
 [[top]]
 = Spring Authorization Server Reference
 
+[IMPORTANT]
+====
+Spring Authorization Server has https://spring.io/blog/2025/09/11/spring-authorization-server-moving-to-spring-security-7-0[moved to Spring Security 7.0] and this documentation is no longer updated for Spring Boot 4.
+If you are on Spring Boot 4 (or migrating), use the Spring Security Authorization Server documentation:
+https://docs.spring.io/spring-security/reference/servlet/oauth2/authorization-server/index.html[Spring Security Authorization Server Reference].
+====
+
 [horizontal]
 xref:overview.adoc[Overview] :: Introduction, use cases and feature list
 xref:getting-help.adoc[Getting Help] :: Links to samples, questions and issues

--- a/docs/modules/ROOT/pages/overview.adoc
+++ b/docs/modules/ROOT/pages/overview.adoc
@@ -1,6 +1,13 @@
 [[overview]]
 = Overview
 
+[IMPORTANT]
+====
+Spring Authorization Server has https://spring.io/blog/2025/09/11/spring-authorization-server-moving-to-spring-security-7-0[moved to Spring Security 7.0] and this documentation is no longer updated for Spring Boot 4.
+If you are on Spring Boot 4 (or migrating), use the Spring Security Authorization Server documentation:
+https://docs.spring.io/spring-security/reference/servlet/oauth2/authorization-server/index.html[Spring Security Authorization Server Reference].
+====
+
 This site contains reference documentation and how-to guides for Spring Authorization Server.
 
 [[introducing-spring-authorization-server]]


### PR DESCRIPTION
## Summary 
- README now uses an IMPORTANT block to highlight the move to Spring Security 7.0 and the new development location.
- Getting Started, Index, and Overview docs include an IMPORTANT notice that this doc set is no longer updated for Spring Boot 4 and link to the Spring Security Authorization Server reference.

Fix #2271 