### PR TITLE
Add authorizationCustomizer pattern for OAuth2Authorization customization

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeRequestAuthenticationContext.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeRequestAuthenticationContext.java
@@ -23,6 +23,7 @@ import java.util.function.Predicate;
 
 import org.springframework.lang.Nullable;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsent;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.util.Assert;
@@ -90,6 +91,15 @@ public final class OAuth2AuthorizationCodeRequestAuthenticationContext implement
 	}
 
 	/**
+	 * Returns the {@link OAuth2Authorization.Builder authorization builder}.
+	 * @return the {@link OAuth2Authorization.Builder}
+	 */
+	@Nullable
+	public OAuth2Authorization.Builder getAuthorizationBuilder() {
+		return get(OAuth2Authorization.Builder.class);
+	}
+
+	/**
 	 * Constructs a new {@link Builder} with the provided
 	 * {@link OAuth2AuthorizationCodeRequestAuthenticationToken}.
 	 * @param authentication the {@link OAuth2AuthorizationCodeRequestAuthenticationToken}
@@ -136,6 +146,15 @@ public final class OAuth2AuthorizationCodeRequestAuthenticationContext implement
 		 */
 		public Builder authorizationConsent(OAuth2AuthorizationConsent authorizationConsent) {
 			return put(OAuth2AuthorizationConsent.class, authorizationConsent);
+		}
+
+		/**
+		 * Sets the {@link OAuth2Authorization.Builder authorization builder}.
+		 * @param authorizationBuilder the {@link OAuth2Authorization.Builder}
+		 * @return the {@link Builder} for further configuration
+		 */
+		public Builder authorizationBuilder(OAuth2Authorization.Builder authorizationBuilder) {
+			return put(OAuth2Authorization.Builder.class, authorizationBuilder);
 		}
 
 		/**

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeRequestAuthenticationProvider.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeRequestAuthenticationProvider.java
@@ -100,6 +100,9 @@ public final class OAuth2AuthorizationCodeRequestAuthenticationProvider implemen
 
 	private Predicate<OAuth2AuthorizationCodeRequestAuthenticationContext> authorizationConsentRequired = OAuth2AuthorizationCodeRequestAuthenticationProvider::isAuthorizationConsentRequired;
 
+	private Consumer<OAuth2AuthorizationCodeRequestAuthenticationContext> authorizationCustomizer = (context) -> {
+	};
+
 	/**
 	 * Constructs an {@code OAuth2AuthorizationCodeRequestAuthenticationProvider} using
 	 * the provided parameters.
@@ -257,9 +260,13 @@ public final class OAuth2AuthorizationCodeRequestAuthenticationProvider implemen
 			}
 
 			String state = DEFAULT_STATE_GENERATOR.generateKey();
-			OAuth2Authorization authorization = authorizationBuilder(registeredClient, principal, authorizationRequest)
-				.attribute(OAuth2ParameterNames.STATE, state)
-				.build();
+			OAuth2Authorization.Builder authorizationBuilder = authorizationBuilder(registeredClient, principal, authorizationRequest)
+				.attribute(OAuth2ParameterNames.STATE, state);
+
+			authenticationContextBuilder.authorizationBuilder(authorizationBuilder);
+			this.authorizationCustomizer.accept(authenticationContextBuilder.build());
+
+			OAuth2Authorization authorization = authorizationBuilder.build();
 
 			if (this.logger.isTraceEnabled()) {
 				this.logger.trace("Generated authorization consent state");
@@ -299,10 +306,14 @@ public final class OAuth2AuthorizationCodeRequestAuthenticationProvider implemen
 			this.logger.trace("Generated authorization code");
 		}
 
-		OAuth2Authorization authorization = authorizationBuilder(registeredClient, principal, authorizationRequest)
+		OAuth2Authorization.Builder authorizationBuilder = authorizationBuilder(registeredClient, principal, authorizationRequest)
 			.authorizedScopes(authorizationRequest.getScopes())
-			.token(authorizationCode)
-			.build();
+			.token(authorizationCode);
+
+		authenticationContextBuilder.authorizationBuilder(authorizationBuilder);
+		this.authorizationCustomizer.accept(authenticationContextBuilder.build());
+
+		OAuth2Authorization authorization = authorizationBuilder.build();
 		this.authorizationService.save(authorization);
 
 		if (this.logger.isTraceEnabled()) {
@@ -393,6 +404,29 @@ public final class OAuth2AuthorizationCodeRequestAuthenticationProvider implemen
 			Predicate<OAuth2AuthorizationCodeRequestAuthenticationContext> authorizationConsentRequired) {
 		Assert.notNull(authorizationConsentRequired, "authorizationConsentRequired cannot be null");
 		this.authorizationConsentRequired = authorizationConsentRequired;
+	}
+
+	/**
+	 * Sets the {@code Consumer} providing access to the
+	 * {@link OAuth2AuthorizationCodeRequestAuthenticationContext} and is responsible for
+	 * customizing the {@link OAuth2Authorization.Builder} prior to building.
+	 * <p>
+	 * The following context attributes are available:
+	 * <ul>
+	 * <li>The {@link RegisteredClient} associated with the authorization request.</li>
+	 * <li>The {@link OAuth2AuthorizationRequest} containing the authorization request
+	 * parameters.</li>
+	 * <li>The {@link OAuth2Authorization.Builder} to be customized.</li>
+	 * </ul>
+	 * @param authorizationCustomizer the {@code Consumer} providing access to the
+	 * {@link OAuth2AuthorizationCodeRequestAuthenticationContext} and is responsible for
+	 * customizing the {@link OAuth2Authorization.Builder} prior to building
+	 * @since 1.4
+	 */
+	public void setAuthorizationCustomizer(
+			Consumer<OAuth2AuthorizationCodeRequestAuthenticationContext> authorizationCustomizer) {
+		Assert.notNull(authorizationCustomizer, "authorizationCustomizer cannot be null");
+		this.authorizationCustomizer = authorizationCustomizer;
 	}
 
 	private static boolean isAuthorizationConsentRequired(

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationConsentAuthenticationContext.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationConsentAuthenticationContext.java
@@ -87,6 +87,15 @@ public final class OAuth2AuthorizationConsentAuthenticationContext implements OA
 	}
 
 	/**
+	 * Returns the {@link OAuth2Authorization.Builder authorization builder}.
+	 * @return the {@link OAuth2Authorization.Builder}
+	 */
+	@Nullable
+	public OAuth2Authorization.Builder getAuthorizationBuilder() {
+		return get(OAuth2Authorization.Builder.class);
+	}
+
+	/**
 	 * Returns the {@link OAuth2AuthorizationRequest authorization request}.
 	 * @return the {@link OAuth2AuthorizationRequest}
 	 */
@@ -140,6 +149,15 @@ public final class OAuth2AuthorizationConsentAuthenticationContext implements OA
 		 */
 		public Builder authorization(OAuth2Authorization authorization) {
 			return put(OAuth2Authorization.class, authorization);
+		}
+
+		/**
+		 * Sets the {@link OAuth2Authorization.Builder authorization builder}.
+		 * @param authorizationBuilder the {@link OAuth2Authorization.Builder}
+		 * @return the {@link Builder} for further configuration
+		 */
+		public Builder authorizationBuilder(OAuth2Authorization.Builder authorizationBuilder) {
+			return put(OAuth2Authorization.Builder.class, authorizationBuilder);
 		}
 
 		/**

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationConsentAuthenticationProvider.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationConsentAuthenticationProvider.java
@@ -80,6 +80,9 @@ public final class OAuth2AuthorizationConsentAuthenticationProvider implements A
 
 	private Consumer<OAuth2AuthorizationConsentAuthenticationContext> authorizationConsentCustomizer;
 
+	private Consumer<OAuth2AuthorizationConsentAuthenticationContext> authorizationCustomizer = (context) -> {
+	};
+
 	/**
 	 * Constructs an {@code OAuth2AuthorizationConsentAuthenticationProvider} using the
 	 * provided parameters.
@@ -239,11 +242,22 @@ public final class OAuth2AuthorizationConsentAuthenticationProvider implements A
 			this.logger.trace("Generated authorization code");
 		}
 
-		OAuth2Authorization updatedAuthorization = OAuth2Authorization.from(authorization)
+		OAuth2Authorization.Builder authorizationBuilder = OAuth2Authorization.from(authorization)
 			.authorizedScopes(authorizedScopes)
 			.token(authorizationCode)
-			.attributes((attrs) -> attrs.remove(OAuth2ParameterNames.STATE))
-			.build();
+			.attributes((attrs) -> attrs.remove(OAuth2ParameterNames.STATE));
+
+		OAuth2AuthorizationConsentAuthenticationContext authorizationConsentAuthenticationContext =
+				OAuth2AuthorizationConsentAuthenticationContext.with(authorizationConsentAuthentication)
+						.authorizationConsent(authorizationConsentBuilder)
+						.registeredClient(registeredClient)
+						.authorization(authorization)
+						.authorizationBuilder(authorizationBuilder)
+						.authorizationRequest(authorizationRequest)
+						.build();
+		this.authorizationCustomizer.accept(authorizationConsentAuthenticationContext);
+
+		OAuth2Authorization updatedAuthorization = authorizationBuilder.build();
 		this.authorizationService.save(updatedAuthorization);
 
 		if (this.logger.isTraceEnabled()) {
@@ -308,6 +322,28 @@ public final class OAuth2AuthorizationConsentAuthenticationProvider implements A
 			Consumer<OAuth2AuthorizationConsentAuthenticationContext> authorizationConsentCustomizer) {
 		Assert.notNull(authorizationConsentCustomizer, "authorizationConsentCustomizer cannot be null");
 		this.authorizationConsentCustomizer = authorizationConsentCustomizer;
+	}
+
+	/**
+	 * Sets the {@code Consumer} providing access to the
+	 * {@link OAuth2AuthorizationConsentAuthenticationContext} and is responsible for
+	 * customizing the {@link OAuth2Authorization.Builder} prior to building.
+	 * <p>
+	 * The following context attributes are available:
+	 * <ul>
+	 * <li>The {@link RegisteredClient} associated with the authorization request.</li>
+	 * <li>The {@link OAuth2Authorization} associated with the state token.</li>
+	 * <li>The {@link OAuth2Authorization.Builder} to be customized.</li>
+	 * </ul>
+	 * @param authorizationCustomizer the {@code Consumer} providing access to the
+	 * {@link OAuth2AuthorizationConsentAuthenticationContext} and is responsible for
+	 * customizing the {@link OAuth2Authorization.Builder} prior to building
+	 * @since 1.4
+	 */
+	public void setAuthorizationCustomizer(
+			Consumer<OAuth2AuthorizationConsentAuthenticationContext> authorizationCustomizer) {
+		Assert.notNull(authorizationCustomizer, "authorizationCustomizer cannot be null");
+		this.authorizationCustomizer = authorizationCustomizer;
 	}
 
 	private static OAuth2TokenContext createAuthorizationCodeTokenContext(

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientCredentialsAuthenticationContext.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientCredentialsAuthenticationContext.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import org.springframework.lang.Nullable;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.util.Assert;
 
@@ -65,6 +66,15 @@ public final class OAuth2ClientCredentialsAuthenticationContext implements OAuth
 	}
 
 	/**
+	 * Returns the {@link OAuth2Authorization.Builder authorization builder}.
+	 * @return the {@link OAuth2Authorization.Builder}
+	 */
+	@Nullable
+	public OAuth2Authorization.Builder getAuthorizationBuilder() {
+		return get(OAuth2Authorization.Builder.class);
+	}
+
+	/**
 	 * Constructs a new {@link Builder} with the provided
 	 * {@link OAuth2ClientCredentialsAuthenticationToken}.
 	 * @param authentication the {@link OAuth2ClientCredentialsAuthenticationToken}
@@ -90,6 +100,15 @@ public final class OAuth2ClientCredentialsAuthenticationContext implements OAuth
 		 */
 		public Builder registeredClient(RegisteredClient registeredClient) {
 			return put(RegisteredClient.class, registeredClient);
+		}
+
+		/**
+		 * Sets the {@link OAuth2Authorization.Builder authorization builder}.
+		 * @param authorizationBuilder the {@link OAuth2Authorization.Builder}
+		 * @return the {@link Builder} for further configuration
+		 */
+		public Builder authorizationBuilder(OAuth2Authorization.Builder authorizationBuilder) {
+			return put(OAuth2Authorization.Builder.class, authorizationBuilder);
 		}
 
 		/**

--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientCredentialsAuthenticationProvider.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientCredentialsAuthenticationProvider.java
@@ -73,6 +73,9 @@ public final class OAuth2ClientCredentialsAuthenticationProvider implements Auth
 
 	private Consumer<OAuth2ClientCredentialsAuthenticationContext> authenticationValidator = new OAuth2ClientCredentialsAuthenticationValidator();
 
+	private Consumer<OAuth2ClientCredentialsAuthenticationContext> authorizationCustomizer = (context) -> {
+	};
+
 	/**
 	 * Constructs an {@code OAuth2ClientCredentialsAuthenticationProvider} using the
 	 * provided parameters.
@@ -160,6 +163,13 @@ public final class OAuth2ClientCredentialsAuthenticationProvider implements Auth
 		OAuth2AccessToken accessToken = OAuth2AuthenticationProviderUtils.accessToken(authorizationBuilder,
 				generatedAccessToken, tokenContext);
 
+		authenticationContext = OAuth2ClientCredentialsAuthenticationContext
+				.with(clientCredentialsAuthentication)
+				.registeredClient(registeredClient)
+				.authorizationBuilder(authorizationBuilder)
+				.build();
+		this.authorizationCustomizer.accept(authenticationContext);
+
 		OAuth2Authorization authorization = authorizationBuilder.build();
 
 		this.authorizationService.save(authorization);
@@ -197,6 +207,27 @@ public final class OAuth2ClientCredentialsAuthenticationProvider implements Auth
 			Consumer<OAuth2ClientCredentialsAuthenticationContext> authenticationValidator) {
 		Assert.notNull(authenticationValidator, "authenticationValidator cannot be null");
 		this.authenticationValidator = authenticationValidator;
+	}
+
+	/**
+	 * Sets the {@code Consumer} providing access to the
+	 * {@link OAuth2ClientCredentialsAuthenticationContext} and is responsible for
+	 * customizing the {@link OAuth2Authorization.Builder} prior to building.
+	 * <p>
+	 * The following context attributes are available:
+	 * <ul>
+	 * <li>The {@link RegisteredClient} associated with the authentication.</li>
+	 * <li>The {@link OAuth2Authorization.Builder} to be customized.</li>
+	 * </ul>
+	 * @param authorizationCustomizer the {@code Consumer} providing access to the
+	 * {@link OAuth2ClientCredentialsAuthenticationContext} and is responsible for
+	 * customizing the {@link OAuth2Authorization.Builder} prior to building
+	 * @since 1.5
+	 */
+	public void setAuthorizationCustomizer(
+			Consumer<OAuth2ClientCredentialsAuthenticationContext> authorizationCustomizer) {
+		Assert.notNull(authorizationCustomizer, "authorizationCustomizer cannot be null");
+		this.authorizationCustomizer = authorizationCustomizer;
 	}
 
 }

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeRequestAuthenticationProviderTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeRequestAuthenticationProviderTests.java
@@ -814,4 +814,43 @@ public class OAuth2AuthorizationCodeRequestAuthenticationProviderTests {
 		assertThat(authorizationCodeRequestAuthentication.getRedirectUri()).isEqualTo(redirectUri);
 	}
 
+	@Test
+	public void setAuthorizationCustomizerWhenNullThenThrowIllegalArgumentException() {
+		assertThatThrownBy(() -> this.authenticationProvider.setAuthorizationCustomizer(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("authorizationCustomizer cannot be null");
+	}
+
+	@Test
+	public void authenticateWhenCustomAuthorizationCustomizerThenUsed() {
+		RegisteredClient registeredClient = TestRegisteredClients.registeredClient().scope("scope1", "scope2").build();
+		given(this.registeredClientRepository.findByClientId(eq(registeredClient.getClientId())))
+			.willReturn(registeredClient);
+
+		Set<String> requestedScopes = registeredClient.getScopes();
+		OAuth2AuthorizationCodeRequestAuthenticationToken authentication = OAuth2AuthorizationCodeRequestAuthenticationToken
+			.with(AUTHORIZATION_URI, registeredClient.getClientId(), this.principal, requestedScopes, STATE)
+			.build();
+
+		Set<String> filteredScopes = Collections.singleton("scope1");
+		this.authenticationProvider.setAuthorizationCustomizer((context) -> {
+			OAuth2Authorization.Builder builder = context.getAuthorizationBuilder();
+			if (builder != null) {
+				builder.authorizedScopes(filteredScopes);
+			}
+		});
+
+		OAuth2AuthorizationCode authorizationCode = createAuthorizationCode();
+		given(this.authorizationService.save(any())).willAnswer((invocation) -> invocation.getArgument(0));
+
+		OAuth2AuthorizationCodeRequestAuthenticationToken authenticationResult = (OAuth2AuthorizationCodeRequestAuthenticationToken) this.authenticationProvider
+			.authenticate(authentication);
+
+		ArgumentCaptor<OAuth2Authorization> authorizationCaptor = ArgumentCaptor.forClass(OAuth2Authorization.class);
+		verify(this.authorizationService).save(authorizationCaptor.capture());
+		OAuth2Authorization authorization = authorizationCaptor.getValue();
+		assertThat(authorization.getAuthorizedScopes()).isEqualTo(filteredScopes);
+		assertThat(authenticationResult.getScopes()).isEqualTo(filteredScopes);
+	}
+
 }

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationConsentAuthenticationProviderTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationConsentAuthenticationProviderTests.java
@@ -533,4 +533,55 @@ public class OAuth2AuthorizationConsentAuthenticationProviderTests {
 		assertThat(authorizationCodeRequestAuthentication.getRedirectUri()).isEqualTo(redirectUri);
 	}
 
+	@Test
+	public void setAuthorizationCustomizerWhenNullThenThrowIllegalArgumentException() {
+		assertThatThrownBy(() -> this.authenticationProvider.setAuthorizationCustomizer(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("authorizationCustomizer cannot be null");
+	}
+
+	@Test
+	public void authenticateWhenCustomAuthorizationCustomizerThenUsed() {
+		RegisteredClient registeredClient = TestRegisteredClients.registeredClient().build();
+		given(this.registeredClientRepository.findByClientId(eq(registeredClient.getClientId())))
+			.willReturn(registeredClient);
+
+		Set<String> requestedScopes = registeredClient.getScopes();
+		OAuth2AuthorizationCodeRequestAuthenticationToken authorizationCodeRequestAuthentication = OAuth2AuthorizationCodeRequestAuthenticationToken
+			.with(AUTHORIZATION_URI, registeredClient.getClientId(), this.principal, requestedScopes, STATE)
+			.build();
+
+		OAuth2Authorization authorization = TestOAuth2Authorizations.authorization(registeredClient,
+				this.principal, authorizationCodeRequestAuthentication).build();
+		given(this.authorizationService.findByToken(eq(authorizationCodeRequestAuthentication.getState()), eq(STATE_TOKEN_TYPE)))
+			.willReturn(authorization);
+
+		OAuth2AuthorizationCodeRequestAuthenticationToken authentication = OAuth2AuthorizationConsentAuthenticationToken
+			.with(AUTHORIZATION_URI, registeredClient.getClientId(), this.principal, requestedScopes, STATE)
+			.build();
+
+		Set<String> filteredScopes = Collections.singleton("scope1");
+		this.authenticationProvider.setAuthorizationCustomizer((context) -> {
+			OAuth2Authorization.Builder builder = context.getAuthorizationBuilder();
+			if (builder != null) {
+				builder.authorizedScopes(filteredScopes);
+			}
+		});
+
+		given(this.authorizationConsentService.findById(eq(registeredClient.getId()), eq(this.principal.getName())))
+			.willReturn(null);
+		given(this.authorizationConsentService.save(any())).willAnswer((invocation) -> invocation.getArgument(0));
+		OAuth2AuthorizationCode authorizationCode = createAuthorizationCode();
+		given(this.authorizationService.save(any())).willAnswer((invocation) -> invocation.getArgument(0));
+
+		OAuth2AuthorizationCodeRequestAuthenticationToken authenticationResult = (OAuth2AuthorizationCodeRequestAuthenticationToken) this.authenticationProvider
+			.authenticate(authentication);
+
+		ArgumentCaptor<OAuth2Authorization> authorizationCaptor = ArgumentCaptor.forClass(OAuth2Authorization.class);
+		verify(this.authorizationService).save(authorizationCaptor.capture());
+		OAuth2Authorization savedAuthorization = authorizationCaptor.getValue();
+		assertThat(savedAuthorization.getAuthorizedScopes()).isEqualTo(filteredScopes);
+		assertThat(authenticationResult.getScopes()).isEqualTo(filteredScopes);
+	}
+
 }

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientCredentialsAuthenticationProviderTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientCredentialsAuthenticationProviderTests.java
@@ -166,6 +166,38 @@ public class OAuth2ClientCredentialsAuthenticationProviderTests {
 	}
 
 	@Test
+	public void setAuthorizationCustomizerWhenNullThenThrowIllegalArgumentException() {
+		assertThatThrownBy(() -> this.authenticationProvider.setAuthorizationCustomizer(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("authorizationCustomizer cannot be null");
+	}
+
+	@Test
+	public void authenticateWhenCustomAuthorizationCustomizerThenUsed() {
+		RegisteredClient registeredClient = TestRegisteredClients.registeredClient2().build();
+		OAuth2ClientAuthenticationToken clientPrincipal = new OAuth2ClientAuthenticationToken(registeredClient,
+				ClientAuthenticationMethod.CLIENT_SECRET_BASIC, registeredClient.getClientSecret());
+		Set<String> requestedScopes = registeredClient.getScopes();
+		OAuth2ClientCredentialsAuthenticationToken authentication = new OAuth2ClientCredentialsAuthenticationToken(
+				clientPrincipal, requestedScopes, null);
+
+		Set<String> mappedScopes = Collections.singleton("scope1");
+		this.authenticationProvider.setAuthorizationCustomizer((context) -> {
+			OAuth2Authorization.Builder builder = context.getAuthorizationBuilder();
+			builder.authorizedScopes(mappedScopes);
+		});
+
+		given(this.jwtEncoder.encode(any())).willReturn(createJwt(mappedScopes));
+
+		this.authenticationProvider.authenticate(authentication);
+
+		ArgumentCaptor<OAuth2Authorization> authorizationCaptor = ArgumentCaptor.forClass(OAuth2Authorization.class);
+		verify(this.authorizationService).save(authorizationCaptor.capture());
+		OAuth2Authorization authorization = authorizationCaptor.getValue();
+		assertThat(authorization.getAuthorizedScopes()).isEqualTo(mappedScopes);
+	}
+
+	@Test
 	public void authenticateWhenClientPrincipalNotOAuth2ClientAuthenticationTokenThenThrowOAuth2AuthenticationException() {
 		RegisteredClient registeredClient = TestRegisteredClients.registeredClient2().build();
 		TestingAuthenticationToken clientPrincipal = new TestingAuthenticationToken(registeredClient.getClientId(),


### PR DESCRIPTION
## Summary

Based on maintainer feedback from @jgrandja, this PR replaces the narrow `OAuth2AuthorizedScopesMapper` with a more general **authorizationCustomizer** pattern.

The new design uses `Consumer<OAuth2XXX_AuthenticationContext>` to customize the `OAuth2Authorization.Builder` before building, providing:

- **Broader applicability**: Not limited to scope filtering - can customize attributes, metadata, tokens, etc.
- **Consistent pattern**: Same pattern used across multiple authentication providers
- **General abstraction**: Aligns with the maintainer's vision for a general "Policy Decision" capability

## Changes

### Authentication Providers Updated

1. **OAuth2AuthorizationCodeRequestAuthenticationProvider**
   - Added `setAuthorizationCustomizer(Consumer<OAuth2AuthorizationCodeRequestAuthenticationContext>)`
   - Customizer called before both authorization consent and authorization code persistence

2. **OAuth2AuthorizationConsentAuthenticationProvider**
   - Added `setAuthorizationCustomizer(Consumer<OAuth2AuthorizationConsentAuthenticationContext>)`
   - Customizer called before authorization update with consent

3. **OAuth2ClientCredentialsAuthenticationProvider**
   - Replaced `setAuthorizedScopesMapper()` with `setAuthorizationCustomizer()`
   - Customizer called before token generation and authorization persistence

### Context Enhancements

Added `getAuthorizationBuilder()` and `authorizationBuilder()` methods to:
- `OAuth2AuthorizationCodeRequestAuthenticationContext`
- `OAuth2AuthorizationConsentAuthenticationContext`
- `OAuth2ClientCredentialsAuthenticationContext`

### Files Changed

**Deleted:**
- `OAuth2AuthorizedScopesMapper.java` (narrow scope)
- `OAuth2AuthorizedScopesContext.java` (narrow scope)

**Modified:**
- 3 Authentication Providers
- 3 Authentication Contexts
- 3 Test Classes

## Usage Example

```java
@Bean
Consumer<OAuth2AuthorizationCodeRequestAuthenticationContext> authorizationCustomizer() {
    return context -> {
        OAuth2Authorization.Builder builder = context.getAuthorizationBuilder();
        
        // Filter scopes based on user roles
        Set<String> filteredScopes = filterScopesByRole(
            builder.<Set<String>>get("authorizedScopes"),
            context.getPrincipal()
        );
        builder.authorizedScopes(filteredScopes);
        
        // Add custom metadata
        builder.attribute("tenantId", getTenantId(context.getPrincipal()));
    };
}
```

## Motivation

This addresses issue #1504 by providing a general-purpose extension point for customizing `OAuth2Authorization` before persistence, enabling use cases such as:

- Role/tenant-based scope filtering
- Adding metadata from upstream authz servers
- Policy-based authorization decisions
- Any other authorization customization needs

## Test plan

- [x] `setAuthorizationCustomizerWhenNullThenThrowIllegalArgumentException` - verifies null check
- [x] `authenticateWhenCustomAuthorizationCustomizerThenUsed` - verifies customizer is invoked
- [x] All existing tests pass
- [x] Checkstyle passes
- [x] Code compiles successfully

Fixes gh-1504

Signed-off-by: Nikita Nagar <permanayan84@gmail.com>