### PR TITLE
Rotated refresh token uses the expiry of initial refresh token

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/token/OAuth2RefreshTokenGenerator.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/token/OAuth2RefreshTokenGenerator.java
@@ -17,13 +17,15 @@ package org.springframework.security.oauth2.server.authorization.token;
 
 import java.time.Instant;
 import java.util.Base64;
+import java.util.Optional;
 
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.springframework.security.crypto.keygen.Base64StringKeyGenerator;
 import org.springframework.security.crypto.keygen.StringKeyGenerator;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
 import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientAuthenticationToken;
 
@@ -50,9 +52,16 @@ public final class OAuth2RefreshTokenGenerator implements OAuth2TokenGenerator<O
 			// Do not issue refresh token to public client
 			return null;
 		}
-
+		var refreshToken = Optional.ofNullable(context.getAuthorization())
+				.map(OAuth2Authorization::getRefreshToken)
+				.orElse(null);
 		Instant issuedAt = Instant.now();
-		Instant expiresAt = issuedAt.plus(context.getRegisteredClient().getTokenSettings().getRefreshTokenTimeToLive());
+		Instant expiresAt;
+		if (refreshToken == null) {
+			expiresAt = issuedAt.plus(context.getRegisteredClient().getTokenSettings().getRefreshTokenTimeToLive());
+		}  else {
+			expiresAt = refreshToken.getToken().getExpiresAt();
+		}
 		return new OAuth2RefreshToken(this.refreshTokenGenerator.generateKey(), issuedAt, expiresAt);
 	}
 

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/token/OAuth2RefreshTokenGeneratorTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/token/OAuth2RefreshTokenGeneratorTests.java
@@ -19,7 +19,9 @@ import java.time.Instant;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
 import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.security.oauth2.server.authorization.client.TestRegisteredClients;
@@ -65,6 +67,34 @@ public class OAuth2RefreshTokenGeneratorTests {
 			.plus(tokenContext.getRegisteredClient().getTokenSettings().getRefreshTokenTimeToLive());
 		assertThat(refreshToken.getIssuedAt()).isBetween(issuedAt.minusSeconds(1), issuedAt.plusSeconds(1));
 		assertThat(refreshToken.getExpiresAt()).isBetween(expiresAt.minusSeconds(1), expiresAt.plusSeconds(1));
+	}
+
+	@Test
+	public void generateWhenAuthorizationContainsRefreshTokenThenReuseExistingExpiresAt() {
+		RegisteredClient registeredClient = TestRegisteredClients.registeredClient().build();
+
+		Instant existingIssuedAt = Instant.now().minusSeconds(60);
+		Instant existingExpiresAt = Instant.now().plusSeconds(3600);
+		OAuth2RefreshToken existingRefreshToken = new OAuth2RefreshToken("existing-token", existingIssuedAt, existingExpiresAt);
+
+		OAuth2Authorization authorization = OAuth2Authorization.withRegisteredClient(registeredClient)
+				.principalName("principal")
+				.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+				.token(existingRefreshToken)
+				.build();
+
+		OAuth2TokenContext tokenContext = DefaultOAuth2TokenContext.builder()
+				.registeredClient(registeredClient)
+				.authorization(authorization)
+				.tokenType(OAuth2TokenType.REFRESH_TOKEN)
+				.build();
+
+		OAuth2RefreshToken generatedRefreshToken = this.tokenGenerator.generate(tokenContext);
+		assertThat(generatedRefreshToken).isNotNull();
+		assertThat(generatedRefreshToken.getExpiresAt()).isEqualTo(existingExpiresAt);
+
+		Instant issuedAt = Instant.now();
+		assertThat(generatedRefreshToken.getIssuedAt()).isBetween(issuedAt.minusSeconds(1), issuedAt.plusSeconds(1));
 	}
 
 }


### PR DESCRIPTION
In Spring Authorization Server, when refresh token rotation is enabled, each newly issued refresh token receives a full TTL. As a result, if a refresh token is rotated close to its expiry, the new token effectively resets its lifetime. This behavior appears to violate the [SPA](https://github.com/spring-projects/spring-authorization-server/issues/297) stated guideline and could introduce a potential security concern.

The fix is to make the changes in OAuth2RefreshTokenGenerator to enable this support by reusing the expiry from the context's authorization model