### PR TITLE
Parse pushed request URI from last delimiter

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2PushedAuthorizationRequestUri.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2PushedAuthorizationRequestUri.java
@@ -59,7 +59,7 @@ final class OAuth2PushedAuthorizationRequestUri {
 
 	static OAuth2PushedAuthorizationRequestUri parse(String requestUri) {
 		int stateStartIndex = REQUEST_URI_PREFIX.length();
-		int expiresAtStartIndex = requestUri.indexOf(REQUEST_URI_DELIMITER) + REQUEST_URI_DELIMITER.length();
+		int expiresAtStartIndex = requestUri.lastIndexOf(REQUEST_URI_DELIMITER) + REQUEST_URI_DELIMITER.length();
 		OAuth2PushedAuthorizationRequestUri pushedAuthorizationRequestUri = new OAuth2PushedAuthorizationRequestUri();
 		pushedAuthorizationRequestUri.requestUri = requestUri;
 		pushedAuthorizationRequestUri.state = requestUri.substring(stateStartIndex);

--- a/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2PushedAuthorizationRequestUriTests.java
+++ b/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2PushedAuthorizationRequestUriTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.authorization.authentication;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link OAuth2PushedAuthorizationRequestUri}.
+ *
+ * @author Goutam Adwant
+ */
+public class OAuth2PushedAuthorizationRequestUriTests {
+
+	@Test
+	public void parseWhenStateContainsDelimiterThenReturnRequestUri() {
+		Instant expiresAt = Instant.parse("2026-06-17T10:00:00Z");
+		String requestUri = "urn:ietf:params:oauth:request_uri:xXMGJTZwzXIFL8i_DFu_EM8IeWC___frCWjpiF2q-xs=___"
+				+ expiresAt.toEpochMilli();
+
+		OAuth2PushedAuthorizationRequestUri pushedAuthorizationRequestUri = OAuth2PushedAuthorizationRequestUri
+			.parse(requestUri);
+
+		assertThat(pushedAuthorizationRequestUri.getRequestUri()).isEqualTo(requestUri);
+		assertThat(pushedAuthorizationRequestUri.getState())
+			.isEqualTo("xXMGJTZwzXIFL8i_DFu_EM8IeWC___frCWjpiF2q-xs=___" + expiresAt.toEpochMilli());
+		assertThat(pushedAuthorizationRequestUri.getExpiresAt()).isEqualTo(expiresAt);
+	}
+
+}


### PR DESCRIPTION
Fixes gh-2346

This updates pushed authorization request URI parsing so the expiration timestamp is read after the last delimiter. The generated state uses Base64 URL characters, so it can contain underscores and may include the same delimiter sequence used before the timestamp.

Tests:
- `./gradlew :spring-security-oauth2-authorization-server:test --tests OAuth2PushedAuthorizationRequestUriTests --tests OAuth2AuthorizationCodeRequestAuthenticationProviderTests --tests OAuth2PushedAuthorizationRequestAuthenticationProviderTests`