### PR TITLE
GH-2333 Document clustered OIDC sessions

### DIFF
--- a/docs/modules/ROOT/pages/core-model-components.adoc
+++ b/docs/modules/ROOT/pages/core-model-components.adoc
@@ -532,3 +532,18 @@ public HttpSessionEventPublisher httpSessionEventPublisher() {
 	return new HttpSessionEventPublisher();
 }
 ----
+
+In a clustered environment, the `SessionRegistry` must also be shared across application instances.
+For example, when using https://docs.spring.io/spring-session/reference/index.html[Spring Session] to back HTTP sessions, register a `SpringSessionBackedSessionRegistry` instead of `SessionRegistryImpl`:
+
+[source,java]
+----
+@Bean
+public SessionRegistry sessionRegistry(
+		FindByIndexNameSessionRepository<? extends Session> sessionRepository) {
+	return new SpringSessionBackedSessionRegistry<>(sessionRepository);
+}
+----
+
+When backing Spring Session with Redis, make sure an indexed session repository is configured, for example with `@EnableRedisIndexedHttpSession`, so that a `FindByIndexNameSessionRepository` is available.
+This allows the OpenID Connect 1.0 Logout Endpoint to validate the `sid` claim even when the logout request is handled by a different application instance than the original login request.

--- a/docs/modules/ROOT/pages/guides/how-to-redis.adoc
+++ b/docs/modules/ROOT/pages/guides/how-to-redis.adoc
@@ -223,3 +223,8 @@ include::{examples-dir}/main/java/sample/redis/config/RedisConfig.java[]
 <4> Register the `RedisRegisteredClientRepository` with the activated `OAuth2RegisteredClientRepository`.
 <5> Register the `RedisOAuth2AuthorizationService` with the activated `OAuth2AuthorizationGrantAuthorizationRepository`.
 <6> Register the `RedisOAuth2AuthorizationConsentService` with the activated `OAuth2UserConsentRepository`.
+
+[NOTE]
+This guide configures Redis-backed implementations for the core services that store authorization server data.
+If OpenID Connect 1.0 is enabled and the authorization server runs in a cluster, HTTP sessions must also be shared across application instances.
+For Redis-backed HTTP sessions, configure Spring Session with an indexed session repository and register a `SpringSessionBackedSessionRegistry` as described in xref:core-model-components.adoc#session-registry[SessionRegistry].


### PR DESCRIPTION
## Summary

- Document that clustered OpenID Connect logout deployments need a shared `SessionRegistry`.
- Show how to register `SpringSessionBackedSessionRegistry` with a Spring Session indexed repository.
- Clarify in the Redis guide that Redis-backed authorization server data is separate from Redis-backed HTTP sessions.

Fixes gh-2333

## Testing

- `git diff --check`
- `./gradlew :spring-authorization-server-docs:antora --console=plain`