### PR TITLE
OAuth2 인증 동의 처리 시 AuthorizationRequest null 검증 추가

### DIFF
--- a/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationConsentAuthenticationProvider.java
+++ b/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationConsentAuthenticationProvider.java
@@ -140,7 +140,15 @@ public final class OAuth2AuthorizationConsentAuthenticationProvider implements A
 		}
 
 		OAuth2AuthorizationRequest authorizationRequest = authorization
-			.getAttribute(OAuth2AuthorizationRequest.class.getName());
+		        .getAttribute(OAuth2AuthorizationRequest.class.getName());
+		
+		if (authorizationRequest == null) {
+		    throwError(OAuth2ErrorCodes.INVALID_REQUEST,
+			OAuth2ParameterNames.STATE,
+			authorizationConsentAuthentication,
+			registeredClient,
+			null);
+		}
 		Set<String> requestedScopes = authorizationRequest.getScopes();
 		Set<String> authorizedScopes = new HashSet<>(authorizationConsentAuthentication.getScopes());
 		if (!requestedScopes.containsAll(authorizedScopes)) {


### PR DESCRIPTION
## 변경 사항

OAuth2 인증 동의(consent) 처리 과정에서 AuthorizationRequest 조회 결과가 null일 경우를 처리하도록 검증 로직을 추가했습니다.

기존에는 AuthorizationRequest가 존재한다고 가정하고 바로 getScopes()를 호출하여, 요청 정보가 없는 상황에서 NullPointerException이 발생할 가능성이 있었습니다.

## 변경 내용

- OAuth2AuthorizationRequest 조회 후 null 여부 검증 추가
- AuthorizationRequest가 없는 경우 INVALID_REQUEST 예외 처리
- 정상적인 AuthorizationRequest가 존재하는 경우 기존 scope 검증 흐름 유지

## 영향 범위

OAuth2 Authorization Consent 처리 흐름에 영향을 줍니다.
기존 정상 요청 흐름에는 영향이 없으며, 잘못된 상태 요청에 대한 예외 처리가 강화됩니다.